### PR TITLE
Add request validation exception handler to FastAPI for nice debugging.

### DIFF
--- a/backend/v1/dev/exception_handlers.py
+++ b/backend/v1/dev/exception_handlers.py
@@ -1,0 +1,20 @@
+from fastapi import FastAPI, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+import json
+import logging
+
+
+def register_exception_handlers(app: FastAPI):
+  @app.exception_handler(RequestValidationError)
+  async def request_validation_exception_handler(request: Request, exc: RequestValidationError):
+      errors = []
+      for error in exc.errors():
+          field_path = ".".join(str(x) for x in error['loc'])
+          message = error['msg']
+          errors.append(f"{message}: `{field_path}`")
+      error_list = " * " + "\n * ".join(errors)
+      request_data = json.loads(await request.body())
+      logging.error(f"RequestValidationError @ {request.method} {request.url.path}\nRequest data: {request_data}\nErrors:\n{error_list}")
+      
+      return JSONResponse(content=errors, status_code=400)

--- a/backend/v1/server.py
+++ b/backend/v1/server.py
@@ -17,6 +17,7 @@ from v1.external.event_site_news import get_event_site_news
 from v1.external.event_api import get_external_event_details
 from v1.user_events.user_events_api import user_events_v1
 from v1.db.mongo import initialize_db
+from v1.dev.exception_handlers import register_exception_handlers
 
 # Initialize logging
 logging.basicConfig(level=logging.INFO)
@@ -34,6 +35,8 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+register_exception_handlers(app)
 
 app.include_router(auth_v1)
 app.include_router(health_v1)


### PR DESCRIPTION
Example output:
```
ERROR:root:RequestValidationError @ PUT /v1/users/me/location
Request data: {'latitude': 58.323250006890724, 'longitude': 13.28426155392541, 'timestamp': None, 'accuracy': 4.730707674886934}
Errors:
 * Input should be a valid integer, got a number with a fractional part: `body.accuracy`
```