### PR TITLE
Implement job scheduling for external events and news refresh

### DIFF
--- a/backend/v1/db/mongo.py
+++ b/backend/v1/db/mongo.py
@@ -48,10 +48,11 @@ def initialize_db():
 
         # Check if in local test mode
         if TEST_MODE.lower() == 'true':
+            pass
             #first clear the collections
             #user_collection.delete_many({})
             #tokenstorage_collection.delete_many({})
-            logging.info("Cleared all collections.")
+            # logging.info("Cleared all collections.")
 
             # Generate and add fake users to the database
             # fake_users = generate_fake_users(10)  # Generate 10 fake users

--- a/backend/v1/google_maps_api/geolocation_api.py
+++ b/backend/v1/google_maps_api/geolocation_api.py
@@ -10,10 +10,14 @@ from v1.env_constants import GOOGLE_MAPS_API_KEY
 
 geolocation_v1 = APIRouter(prefix="/v1")
 
-gmaps = googlemaps.Client(key=GOOGLE_MAPS_API_KEY)
+if GOOGLE_MAPS_API_KEY and GOOGLE_MAPS_API_KEY == "":
+    gmaps = googlemaps.Client(key=GOOGLE_MAPS_API_KEY)
 
 @geolocation_v1.get("/geolocation/{address}")
 def getLocationByAdress(address : str, current_user: dict = Depends(validate_request)) -> GeoLocation:
+    if not GOOGLE_MAPS_API_KEY or GOOGLE_MAPS_API_KEY == "":
+        raise HTTPException(status_code=500, detail="Google Maps API key is not configured")
+    
     # This function will get the location of the given address
     
     # Geocoding an address

--- a/backend/v1/jobs/refresh_events.py
+++ b/backend/v1/jobs/refresh_events.py
@@ -1,0 +1,31 @@
+from v1.db.external_events import (
+    clean_external_events,
+    get_stored_external_event_details,
+)
+from v1.external.event_api import get_external_root, get_external_event_details
+import logging
+
+def refresh_external_events():
+    root = get_external_root()
+    if not root or not root.restUrl or root.restUrl == "" or not root.dates:
+        logging.error("Failed to fetch external root or missing data.")
+        return
+
+    all_external_events = []
+    for date in root.dates:
+        date_external_events = get_external_event_details(root.restUrl, date)
+        if date_external_events:
+            all_external_events.extend(date_external_events)
+    
+    # Remove external events that are not in the list of all_external_events
+    clean_external_events(keeping=all_external_events)
+
+    # Triple checking. Check that each of all_external_events is still in the database,
+    # using get_stored_external_event_details
+    for event in all_external_events:
+        event_id = event.eventId
+        # Check if the event is in the database
+        stored_event = get_stored_external_event_details(event_ids=[event_id])
+        if not stored_event:
+            logging.error(f"Event {event_id} not found in the database after cleaning.")
+            continue

--- a/backend/v1/jobs/refresh_news.py
+++ b/backend/v1/jobs/refresh_news.py
@@ -1,0 +1,11 @@
+from v1.external.event_api import get_external_root
+from v1.external.event_site_news import get_event_site_news
+import logging
+
+def refresh_external_news():
+    root = get_external_root()
+    if not root or not root.restUrl:
+        logging.error("Failed to fetch external root or missing restUrl.")
+        return
+
+    get_event_site_news(root.restUrl)

--- a/backend/v1/jobs/scheduler.py
+++ b/backend/v1/jobs/scheduler.py
@@ -1,0 +1,99 @@
+# scheduler.py
+import os
+import logging
+from datetime import datetime
+
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.triggers.cron import CronTrigger
+from apscheduler.triggers.interval import IntervalTrigger
+from v1.jobs.refresh_events import refresh_external_events
+from v1.jobs.refresh_news import refresh_external_news
+
+log = logging.getLogger(__name__)
+
+
+class JobConfig:
+    def __init__(self, name, func, default_schedule, env_prefix, init=False):
+        self.name = name
+        self.func = func
+        self.default_schedule = default_schedule  # dict, e.g. {"type": "interval", "seconds": 60}
+        self.env_prefix = env_prefix             # e.g. "CLEANUP_JOB"
+        self.init = init # bool, whether to run the job immediately on startup
+
+    def is_enabled(self) -> bool:
+        return os.getenv(f"{self.env_prefix}_ENABLED", "true").lower() == "true"
+
+    def build_trigger(self):
+        """
+        Build APScheduler trigger from env or default.
+        Examples:
+          CLEANUP_JOB_CRON="0 */5 * * *"
+          CLEANUP_JOB_INTERVAL_SECONDS=300
+        """
+        cron_expr = os.getenv(f"{self.env_prefix}_CRON")
+        interval_seconds = os.getenv(f"{self.env_prefix}_PERIOD")
+
+        if cron_expr:
+            # simple "m h dom mon dow"
+            minute, hour, day, month, dow = cron_expr.split()
+            return CronTrigger(
+                minute=minute, hour=hour, day=day, month=month, day_of_week=dow
+            )
+
+        if interval_seconds:
+            return IntervalTrigger(seconds=int(interval_seconds))
+
+        # fall back to default
+        t = self.default_schedule
+        if t["type"] == "interval":
+            return IntervalTrigger(**{k: v for k, v in t.items() if k != "type"})
+        elif t["type"] == "cron":
+            return CronTrigger(**{k: v for k, v in t.items() if k != "type"})
+        else:
+            raise ValueError(f"Unknown trigger type {t['type']}")
+
+
+JOB_REGISTRY = [
+    JobConfig(
+        name="sync_external_events",
+        func=refresh_external_events,
+        default_schedule={"type": "cron", "minute": "*/15"},
+        env_prefix="SYNC_EXTERNAL_EVENTS",
+        init=True,
+    ),
+    JobConfig(
+        name="refresh_external_news",
+        func=refresh_external_news,
+        default_schedule={"type": "cron", "minute": "*/30"},
+        env_prefix="REFRESH_EXTERNAL_NEWS",
+        init=True,
+    ),
+]
+
+
+def create_scheduler() -> BackgroundScheduler:
+    scheduler = BackgroundScheduler(timezone="UTC")
+
+    for job_cfg in JOB_REGISTRY:
+        if not job_cfg.is_enabled():
+            log.info("Job %s disabled via env", job_cfg.name)
+            continue
+
+        trigger = job_cfg.build_trigger()
+        scheduler.add_job(
+            job_cfg.func,
+            trigger=trigger,
+            id=job_cfg.name,
+            replace_existing=True,
+            max_instances=1,
+        )
+        log.info("Scheduled job %s with trigger %s", job_cfg.name, trigger)
+
+        if job_cfg.init:
+            log.info("Running job %s immediately on startup", job_cfg.name)
+            try:
+                job_cfg.func()
+            except Exception as e:
+                log.error("Error running job %s on startup: %s", job_cfg.name, e)
+
+    return scheduler

--- a/backend/v1/requirements.txt
+++ b/backend/v1/requirements.txt
@@ -12,6 +12,7 @@ uvicorn # ASGI server for FastAPI
 sqlalchemy # ORM for databases
 faker # Fake data generator
 googlemaps # Google Maps API
+apscheduler # Scheduling periodic tasks
 
 # Documentation
 sphinx


### PR DESCRIPTION
Job scheduling are configured in `JOB_REGISTRY` in `backend/v1/jobs/scheduler.py`.

Each job has two env vars, `{PREFIX}_CRON` and `{PREFIX}_INTERVAL`.
- `{PREFIX}_CRON`: [Standard cron string](https://linuxhandbook.com/crontab/), i.e. "0 */5 * * *" for running at minute zero every five hours.
- `{PREFIX}_INTERVAL`: seconds between job runs.

If both are configured, _CRON takes precedence.

## Jobs added:
### Sync external events
Prefix: `SYNC_EXTERNAL_EVENTS`
Default: **every 15 minutes**

### Refresh external news
  Prefix: `REFRESH_EXTERNAL_NEWS`
  Default: **every 30 minutes**