### PR TITLE
refreshAccessToken awaited so it is not silently discarded

### DIFF
--- a/mensasverige/features/common/services/authService.ts
+++ b/mensasverige/features/common/services/authService.ts
@@ -109,9 +109,7 @@ export const refreshAccessToken = async (refreshToken: string): Promise<string> 
     const response = await authClient.post('/refresh_token', { refresh_token: refreshToken });
     if (response.status === 200) {
         const data: AuthResponse = response.data;
-        await SecureStore.setItemAsync('accessToken', data.accessToken);
-        await SecureStore.setItemAsync('accessTokenExpiry', data.accessTokenExpiry.toString());
-        await SecureStore.setItemAsync('refreshToken', data.refreshToken);
+        await storeAndValidateAuthResponse(data);
         return data.accessToken;
     }
     throw new Error('Failed to refresh access token');

--- a/mensasverige/features/common/services/authService.ts
+++ b/mensasverige/features/common/services/authService.ts
@@ -27,7 +27,7 @@
  */
 
 import { AuthRequest, AuthResponse, HTTPValidationError, ValidationError } from '../../../api_schema/types';
-import axios, { AxiosResponse } from 'axios';
+import axios from 'axios';
 import * as SecureStore from "expo-secure-store";
 
 const authClient = axios.create({
@@ -106,19 +106,15 @@ export const getOrRefreshAccessToken = async (): Promise<string> => {
 }
 
 export const refreshAccessToken = async (refreshToken: string): Promise<string> => {
-    return authClient
-        .post('/refresh_token', { refresh_token: refreshToken })
-        .then((response: AxiosResponse) => {
-            if (response.status === 200) {
-                const data: AuthResponse = response.data;
-                console.log('Auth response', data);
-                storeAndValidateAuthResponse(data);
-                return data.accessToken;
-            }
-            else {
-                return Promise.reject('Failed to refresh access token');
-            }
-        })
+    const response = await authClient.post('/refresh_token', { refresh_token: refreshToken });
+    if (response.status === 200) {
+        const data: AuthResponse = response.data;
+        await SecureStore.setItemAsync('accessToken', data.accessToken);
+        await SecureStore.setItemAsync('accessTokenExpiry', data.accessTokenExpiry.toString());
+        await SecureStore.setItemAsync('refreshToken', data.refreshToken);
+        return data.accessToken;
+    }
+    throw new Error('Failed to refresh access token');
 }
 
 export const attemptLoginWithStoredCredentials = async (): Promise<AuthResponse> => {


### PR DESCRIPTION
fixes #239 

Problem was that the refreshauthtoken wasnt awaited and silently ignored and thus only using the old outdated tokens