### PR TITLE
Refactor safe area insets to layout instead of indivitual screens

### DIFF
--- a/mensasverige/app/(tabs)/_layout.tsx
+++ b/mensasverige/app/(tabs)/_layout.tsx
@@ -1,7 +1,7 @@
 import { Tabs } from 'expo-router';
 import React from 'react';
 import { Platform } from 'react-native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useSafeAreaInsets, SafeAreaView } from 'react-native-safe-area-context';
 import { Image } from 'expo-image';
 
 import { HapticTab } from '@/components/HapticTab';
@@ -20,7 +20,7 @@ export default function TabLayout() {
   const user = useStore(state => state.user);
 
   return (
-    <>
+    <SafeAreaView edges={['top']} style={{ flex: 1 }}>
     <UpdateBanner />
     <Tabs
       screenOptions={{
@@ -69,6 +69,6 @@ export default function TabLayout() {
         }}
       />
     </Tabs>
-    </>
+    </SafeAreaView>
   );
 }

--- a/mensasverige/features/account/screens/UserProfile.tsx
+++ b/mensasverige/features/account/screens/UserProfile.tsx
@@ -103,7 +103,7 @@ const UserProfile: React.FC = () => {
             <ScrollView
                 contentContainerStyle={[
                     styles.scroll,
-                    { paddingTop: insets.top + 8, paddingBottom: insets.bottom + 24 },
+                    { paddingTop: 8, paddingBottom: insets.bottom + 24 },
                 ]}
                 showsVerticalScrollIndicator={false}>
 

--- a/mensasverige/features/common/screens/WelcomeScreen.tsx
+++ b/mensasverige/features/common/screens/WelcomeScreen.tsx
@@ -11,7 +11,7 @@ export default function WelcomeScreen() {
     const { user } = useStore();
     return (
         <>
-            <ParallaxScrollView useSafeArea={true}
+            <ParallaxScrollView
                 headerImage={
                     <Image
                         source={require('@/assets/images/mensa_sverige_1024_500.jpg')}

--- a/mensasverige/features/events/screens/ActivitiesList.tsx
+++ b/mensasverige/features/events/screens/ActivitiesList.tsx
@@ -130,7 +130,7 @@ export const ActivitiesList: React.FC<ActivitiesListProps> = ({ initialFilter })
     };
 
     return (
-        <ThemedView useSafeArea={true} style={{ flex: 1 }}>
+        <ThemedView style={{ flex: 1 }}>
             <UnifiedEventModal
                 event={selectedEvent || undefined}
                 open={!!selectedEvent || showCreateForm}

--- a/mensasverige/features/map/components/SearchParticipants.tsx
+++ b/mensasverige/features/map/components/SearchParticipants.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import { View, StyleSheet, TextInput, TouchableOpacity } from 'react-native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { Colors } from '@/constants/Colors';
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 
-const createStyles = (colorScheme: string, topInset: number) => StyleSheet.create({
+const createStyles = (colorScheme: string) => StyleSheet.create({
   searchContainer: {
     backgroundColor: colorScheme === 'dark' ? '#1f2937' : '#ffffff',
     borderRadius: 8,
@@ -14,7 +13,6 @@ const createStyles = (colorScheme: string, topInset: number) => StyleSheet.creat
     paddingHorizontal: 12,
     paddingVertical: 8,
     margin: 16,
-    marginTop: topInset + 16,
     shadowColor: '#000',
     shadowOffset: {
       width: 0,
@@ -49,8 +47,7 @@ export const SearchParticipants: React.FC<SearchParticipantsProps> = ({
   placeholder = "Sök deltagare..." 
 }) => {
   const colorScheme = useColorScheme();
-  const insets = useSafeAreaInsets();
-  const styles = createStyles(colorScheme ?? 'light', insets.top);
+  const styles = createStyles(colorScheme ?? 'light');
 
   return (
     <View style={styles.searchContainer}>

--- a/mensasverige/features/updateCheck/components/UpdateBanner.tsx
+++ b/mensasverige/features/updateCheck/components/UpdateBanner.tsx
@@ -1,21 +1,18 @@
 import React from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { MaterialIcons } from '@expo/vector-icons';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import useStore from '@/features/common/store/store';
 import { Colors } from '@/constants/Colors';
 import { openStoreUrl } from '../functions/openStoreUrl';
 
 export const UpdateBanner: React.FC = () => {
   const { updateAvailableInfo } = useStore();
-  const insets = useSafeAreaInsets();
 
   if (!updateAvailableInfo) {
     return null;
   }
 
   return (
-    <View style={{ paddingTop: insets.top }}>
     <TouchableOpacity
       activeOpacity={0.85}
       style={styles.bannerContainer}
@@ -30,7 +27,7 @@ export const UpdateBanner: React.FC = () => {
             Uppdatering tillgänglig
           </Text>
           <Text style={styles.bannerMessage}>
-            En ny version av appen finns nu tillgänglig. 
+            En ny version av appen finns nu tillgänglig.
           </Text>
         </View>
         <View style={styles.bannerButton}>
@@ -38,7 +35,6 @@ export const UpdateBanner: React.FC = () => {
         </View>
       </View>
     </TouchableOpacity>
-    </View>
   );
 };
 


### PR DESCRIPTION
Refactor layout components: remove unnecessary useSafeAreaInsets imports and adjust padding in TabLayout, UserProfile, ActivitiesList, SearchParticipants, WelcomeScreen, and UpdateBanner
