### PR TITLE
Fix dependabot directory paths

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@
 version: 2
 updates:
   - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/app" # Location of package manifests
+    directory: "/mensasverige" # Location of package manifests
     schedule:
       interval: "weekly"
     reviewers:
@@ -22,7 +22,7 @@ updates:
            - "minor"
     
   - package-ecosystem: "pip"
-    directory: "/backend"
+    directory: "/backend/v1"
     schedule:
       interval: "weekly"
     reviewers:


### PR DESCRIPTION
## Summary
- npm manifest moved from \`/app\` to \`/mensasverige\` during the Expo migration.
- pip manifest lives at \`/backend/v1/requirements.txt\`, not \`/backend\`.
- Dependabot has been failing on both manifests on every weekly run; latest example: https://github.com/MensaSverige/swagapp/actions/runs/25658292010.

## Test plan
- [ ] Merge.
- [ ] Trigger Dependabot manually (or wait for next weekly run); confirm the npm + pip update jobs succeed and open their respective PRs.