### PR TITLE
Prominent disclosure modal before background location request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,5 @@ yarn-error.log
 /docs/frontend
 /docs/source/*.rst
 !/docs/source/index.rst
+
+.grit-cache

--- a/mensasverige/features/account/components/BackgroundLocationDisclosure.tsx
+++ b/mensasverige/features/account/components/BackgroundLocationDisclosure.tsx
@@ -1,0 +1,148 @@
+import React from 'react';
+import {
+  Modal,
+  View,
+  StyleSheet,
+  ScrollView,
+  useColorScheme,
+} from 'react-native';
+import { ThemedView } from '@/components/ThemedView';
+import { ThemedText } from '@/components/ThemedText';
+import { ThemedButton } from '@/components/ThemedButton';
+import { Colors } from '@/constants/Colors';
+
+type Props = {
+  visible: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+};
+
+const BackgroundLocationDisclosure: React.FC<Props> = ({
+  visible,
+  onConfirm,
+  onCancel,
+}) => {
+  const colorScheme = useColorScheme() ?? 'light';
+  const overlay = colorScheme === 'dark' ? 'rgba(0,0,0,0.75)' : 'rgba(0,0,0,0.55)';
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onCancel}>
+      <View style={[styles.overlay, { backgroundColor: overlay }]}>
+        <ThemedView style={styles.card}>
+          <ScrollView
+            contentContainerStyle={styles.scroll}
+            showsVerticalScrollIndicator={false}>
+            <ThemedText type="title" style={styles.title}>
+              Dela plats i bakgrunden
+            </ThemedText>
+
+            <ThemedText style={styles.body}>
+              Mensa Sverige-appen kan dela din plats med andra Mensamedlemmar
+              på kartan även när appen är stängd eller i bakgrunden.
+            </ThemedText>
+
+            <ThemedText type="defaultSemiBold" style={styles.sectionTitle}>
+              Vad samlas in
+            </ThemedText>
+            <ThemedText style={styles.body}>
+              Din exakta plats (latitud och longitud) skickas till Mensa
+              Sveriges server och visas på kartan för andra inloggade
+              medlemmar enligt dina sekretessinställningar.
+            </ThemedText>
+
+            <ThemedText type="defaultSemiBold" style={styles.sectionTitle}>
+              När den används
+            </ThemedText>
+            <ThemedText style={styles.body}>
+              Platsen uppdateras enligt det intervall du valt under
+              Platsuppdatering. Med bakgrundsdelning aktiverad fortsätter
+              uppdateringarna även när du inte aktivt använder appen.
+            </ThemedText>
+
+            <ThemedText type="defaultSemiBold" style={styles.sectionTitle}>
+              Din kontroll
+            </ThemedText>
+            <ThemedText style={styles.body}>
+              Du kan stänga av bakgrundsdelning när som helst i den här
+              vyn. Du styr också vem som ser din plats under Sekretess.
+            </ThemedText>
+
+            <ThemedText style={styles.note}>
+              Om du fortsätter visar din enhet en systemfråga där du
+              väljer hur appen får använda platstjänster.
+            </ThemedText>
+
+            <View style={styles.buttons}>
+              <ThemedButton
+                text="Avbryt"
+                variant="secondary"
+                onPress={onCancel}
+                style={styles.button}
+              />
+              <ThemedButton
+                text="Fortsätt"
+                variant="primary"
+                onPress={onConfirm}
+                style={styles.button}
+              />
+            </View>
+          </ScrollView>
+        </ThemedView>
+      </View>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 20,
+  },
+  card: {
+    width: '100%',
+    maxWidth: 480,
+    maxHeight: '90%',
+    borderRadius: 16,
+    overflow: 'hidden',
+    shadowColor: '#000',
+    shadowOpacity: 0.25,
+    shadowRadius: 16,
+    shadowOffset: { width: 0, height: 8 },
+    elevation: 8,
+  },
+  scroll: {
+    padding: 24,
+  },
+  title: {
+    marginBottom: 12,
+  },
+  sectionTitle: {
+    marginTop: 16,
+    marginBottom: 4,
+  },
+  body: {
+    fontSize: 14,
+    lineHeight: 20,
+    opacity: 0.85,
+  },
+  note: {
+    marginTop: 20,
+    fontSize: 12,
+    fontStyle: 'italic',
+    opacity: 0.65,
+    lineHeight: 17,
+  },
+  buttons: {
+    marginTop: 24,
+    gap: 10,
+  },
+  button: {},
+});
+
+export default BackgroundLocationDisclosure;

--- a/mensasverige/features/account/screens/AppSettings.tsx
+++ b/mensasverige/features/account/screens/AppSettings.tsx
@@ -9,6 +9,7 @@ import { updateUser } from '../services/userService';
 import { Colors } from '@/constants/Colors';
 import { DEFAULT_SETTINGS } from '@/constants/DefaultSettings';
 import { useToast } from '@/hooks/useToast';
+import BackgroundLocationDisclosure from '../components/BackgroundLocationDisclosure';
 
 type AppForm = {
     location_update_interval_seconds: number;
@@ -40,6 +41,7 @@ const AppSettings: React.FC = () => {
 
     const [tempLocation, setTempLocation] = useState(form.location_update_interval_seconds);
     const [tempEvents, setTempEvents] = useState(form.events_refresh_interval_seconds);
+    const [disclosureVisible, setDisclosureVisible] = useState(false);
 
     useEffect(() => {
         if (!initializedRef.current) {
@@ -162,9 +164,13 @@ const AppSettings: React.FC = () => {
                         </View>
                         <Switch
                             value={form.background_location_updates}
-                            onValueChange={v =>
-                                setForm(f => ({ ...f, background_location_updates: v }))
-                            }
+                            onValueChange={v => {
+                                if (v) {
+                                    setDisclosureVisible(true);
+                                } else {
+                                    setForm(f => ({ ...f, background_location_updates: false }));
+                                }
+                            }}
                             trackColor={{ false: Colors.coolGray500, true: Colors.primary500 }}
                             thumbColor={
                                 form.background_location_updates ? Colors.white : Colors.coolGray100
@@ -174,6 +180,15 @@ const AppSettings: React.FC = () => {
                 </ThemedView>
 
             </ScrollView>
+
+            <BackgroundLocationDisclosure
+                visible={disclosureVisible}
+                onConfirm={() => {
+                    setDisclosureVisible(false);
+                    setForm(f => ({ ...f, background_location_updates: true }));
+                }}
+                onCancel={() => setDisclosureVisible(false)}
+            />
         </ThemedView>
     );
 };


### PR DESCRIPTION
## Summary
- Adds `BackgroundLocationDisclosure.tsx` — themed modal explaining what location data is collected, when it's used, and how the user controls it
- Wires the modal into `AppSettings.tsx`: flipping the background-location switch ON now opens the modal first; the setting only flips `true` after the user taps **Fortsätt**. Switching OFF stays immediate.
- Adds `.grit-cache` to `.gitignore`

## Why
Google Play policy requires an in-app disclosure of background location data collection and use **before** the OS permission prompt. The previous flow flipped the setting and fired `Location.requestBackgroundPermissionsAsync()` with zero disclosure — one of the two blockers on the 2.1.5 production release (the other is the FGS demo video URL in the Play Console).

## Test plan
- [ ] Open Settings → App → Bakgrundsplatsuppdateringar switch
- [ ] Toggle ON → disclosure modal appears with Swedish copy
- [ ] Tap **Avbryt** → modal closes, switch stays off
- [ ] Toggle ON → tap **Fortsätt** → modal closes, setting flips true, OS background-location prompt appears
- [ ] Toggle OFF → setting flips false immediately, no modal

🤖 Tracked in grit-task swagapp-a9dr4