### PR TITLE
feat: event participation — populate attendees on external events

### DIFF
--- a/backend/__tests__/unified_events-test.py
+++ b/backend/__tests__/unified_events-test.py
@@ -249,3 +249,33 @@ def test_list_unified_events_admin_sees_attendees_even_if_show_booked_false(monk
     assert len(ext_events) == 1
     assert {a.userId for a in ext_events[0].attendees} == {7, 8}
 
+
+# ── book/unbook booking sync tests ──────────────────────────────────────────
+
+def test_attend_external_event_syncs_booking(monkeypatch):
+    import v1.events.events_service as svc
+
+    ext = make_external_event(400)
+    added = []
+
+    monkeypatch.setattr(svc, "book_external_event", lambda uid, eid: {"status": "OK"})
+    monkeypatch.setattr(svc, "get_all_stored_external_event_details", lambda: [ext])
+    monkeypatch.setattr(svc, "get_booked_external_events", lambda uid: [])
+    monkeypatch.setattr(svc, "add_booking", lambda userId, eventId: added.append((userId, eventId)))
+
+    current_user = {"userId": 5, "settings": {}, "isMember": True}
+    svc._attend_external_event("ext400", current_user)
+    assert (5, 400) in added
+
+
+def test_unattend_external_event_syncs_booking(monkeypatch):
+    import v1.events.events_service as svc
+
+    deleted = []
+    monkeypatch.setattr(svc, "unbook_external_event", lambda uid, eid: {"status": "OK"})
+    monkeypatch.setattr(svc, "delete_booking", lambda userId, eventId: deleted.append((userId, eventId)))
+
+    current_user = {"userId": 5, "settings": {}, "isMember": True}
+    svc._unattend_external_event("ext400", current_user)
+    assert (5, 400) in deleted
+

--- a/backend/__tests__/unified_events-test.py
+++ b/backend/__tests__/unified_events-test.py
@@ -188,3 +188,64 @@ def test_map_external_event_empty_set_gives_empty():
     mapped = map_external_event(ext, current_user_id=1, booked_ids=set(), attendee_user_ids=set())
     assert mapped.attendees == []
 
+
+# ── list_unified_events attendee propagation ─────────────────────────────────
+
+def test_list_unified_events_populates_attendees_when_show_booked(monkeypatch):
+    import v1.events.events_service as svc
+
+    ext = make_external_event(300, booked=1)
+    ext.showBooked = True
+
+    monkeypatch.setattr(svc, "get_booked_external_events", lambda uid: [])
+    monkeypatch.setattr(svc, "get_all_stored_external_event_details", lambda: [ext])
+    monkeypatch.setattr(svc, "get_safe_user_events_since", lambda since: [])
+    monkeypatch.setattr(svc, "get_users_by_ids", lambda ids: [])
+    monkeypatch.setattr(svc, "get_bookings_by_event_ids", lambda ids: {300: {42}})
+
+    current_user = {"userId": 1, "isMember": True, "settings": {}}
+    events = svc.list_unified_events(current_user)
+    ext_events = [e for e in events if e.id == "ext300"]
+    assert len(ext_events) == 1
+    assert {a.userId for a in ext_events[0].attendees} == {42}
+
+
+def test_list_unified_events_no_attendees_when_show_booked_false_and_not_admin(monkeypatch):
+    import v1.events.events_service as svc
+
+    ext = make_external_event(301, booked=5)
+    ext.showBooked = False
+    ext.admins = None
+
+    monkeypatch.setattr(svc, "get_booked_external_events", lambda uid: [])
+    monkeypatch.setattr(svc, "get_all_stored_external_event_details", lambda: [ext])
+    monkeypatch.setattr(svc, "get_safe_user_events_since", lambda since: [])
+    monkeypatch.setattr(svc, "get_users_by_ids", lambda ids: [])
+    monkeypatch.setattr(svc, "get_bookings_by_event_ids", lambda ids: {301: {42}})
+
+    current_user = {"userId": 1, "isMember": True, "settings": {}}
+    events = svc.list_unified_events(current_user)
+    ext_events = [e for e in events if e.id == "ext301"]
+    assert len(ext_events) == 1
+    assert ext_events[0].attendees == []
+
+
+def test_list_unified_events_admin_sees_attendees_even_if_show_booked_false(monkeypatch):
+    import v1.events.events_service as svc
+
+    ext = make_external_event(302, booked=2)
+    ext.showBooked = False
+    ext.admins = ["99"]  # userId 99 is admin
+
+    monkeypatch.setattr(svc, "get_booked_external_events", lambda uid: [])
+    monkeypatch.setattr(svc, "get_all_stored_external_event_details", lambda: [ext])
+    monkeypatch.setattr(svc, "get_safe_user_events_since", lambda since: [])
+    monkeypatch.setattr(svc, "get_users_by_ids", lambda ids: [])
+    monkeypatch.setattr(svc, "get_bookings_by_event_ids", lambda ids: {302: {7, 8}})
+
+    current_user = {"userId": 99, "isMember": True, "settings": {}}
+    events = svc.list_unified_events(current_user)
+    ext_events = [e for e in events if e.id == "ext302"]
+    assert len(ext_events) == 1
+    assert {a.userId for a in ext_events[0].attendees} == {7, 8}
+

--- a/backend/__tests__/unified_events-test.py
+++ b/backend/__tests__/unified_events-test.py
@@ -112,3 +112,59 @@ def test_filter_event_attendees_also_filters_attendee_names(monkeypatch):
     assert [a.userId for a in result.attendees] == [11]
     assert result.extras["attendeeNames"] == ["Visible User"]
 
+
+# ── ExternalBookings CRUD tests ─────────────────────────────────────────────
+
+def test_get_bookings_by_event_ids_groups_correctly(monkeypatch):
+    """get_bookings_by_event_ids groups results by eventId."""
+    from v1.db import external_bookings as eb
+
+    class FakeCol:
+        def find(self, query):
+            return [
+                {"userId": 1, "eventId": 10},
+                {"userId": 2, "eventId": 10},
+                {"userId": 3, "eventId": 20},
+            ]
+
+    monkeypatch.setattr(eb, "external_event_bookings_collection", FakeCol())
+
+    result = eb.get_bookings_by_event_ids([10, 20])
+    assert set(result[10]) == {1, 2}
+    assert set(result[20]) == {3}
+
+
+def test_get_bookings_by_event_ids_empty_returns_empty(monkeypatch):
+    from v1.db import external_bookings as eb
+    # When called with empty list, return empty dict without hitting DB
+    result = eb.get_bookings_by_event_ids([])
+    assert result == {}
+
+
+def test_delete_user_bookings(monkeypatch):
+    from v1.db import external_bookings as eb
+
+    deleted_filter = []
+
+    class FakeCol:
+        def delete_many(self, f):
+            deleted_filter.append(f)
+
+    monkeypatch.setattr(eb, "external_event_bookings_collection", FakeCol())
+    eb.delete_user_bookings(userId=5)
+    assert deleted_filter == [{"userId": 5}]
+
+
+def test_delete_booking(monkeypatch):
+    from v1.db import external_bookings as eb
+
+    deleted = []
+
+    class FakeCol:
+        def delete_one(self, f):
+            deleted.append(f)
+
+    monkeypatch.setattr(eb, "external_event_bookings_collection", FakeCol())
+    eb.delete_booking(userId=5, eventId=99)
+    assert deleted == [{"userId": 5, "eventId": 99}]
+

--- a/backend/__tests__/unified_events-test.py
+++ b/backend/__tests__/unified_events-test.py
@@ -168,3 +168,23 @@ def test_delete_booking(monkeypatch):
     eb.delete_booking(userId=5, eventId=99)
     assert deleted == [{"userId": 5, "eventId": 99}]
 
+
+# ── map_external_event attendee tests ────────────────────────────────────────
+
+def test_map_external_event_with_attendee_ids():
+    ext = make_external_event(200, booked=2)
+    mapped = map_external_event(ext, current_user_id=1, booked_ids={200}, attendee_user_ids={1, 7})
+    assert {a.userId for a in mapped.attendees} == {1, 7}
+
+
+def test_map_external_event_no_attendee_ids_gives_empty():
+    ext = make_external_event(201)
+    mapped = map_external_event(ext, current_user_id=1, booked_ids=set(), attendee_user_ids=None)
+    assert mapped.attendees == []
+
+
+def test_map_external_event_empty_set_gives_empty():
+    ext = make_external_event(202)
+    mapped = map_external_event(ext, current_user_id=1, booked_ids=set(), attendee_user_ids=set())
+    assert mapped.attendees == []
+

--- a/backend/v1/db/external_bookings.py
+++ b/backend/v1/db/external_bookings.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+import logging
+from typing import Dict, List, Set
+from pymongo import UpdateOne
+from v1.db.mongo import external_event_bookings_collection
+
+
+def upsert_user_bookings(userId: int, event_ids: List[int]) -> None:
+    """Replace all bookings for userId with the given event_ids."""
+    if not event_ids:
+        delete_user_bookings(userId)
+        return
+    ops = [
+        UpdateOne(
+            {"userId": userId, "eventId": eid},
+            {"$setOnInsert": {"userId": userId, "eventId": eid}},
+            upsert=True,
+        )
+        for eid in event_ids
+    ]
+    try:
+        external_event_bookings_collection.bulk_write(ops, ordered=False)
+        external_event_bookings_collection.delete_many(
+            {"userId": userId, "eventId": {"$nin": event_ids}}
+        )
+    except Exception as e:
+        logging.error(f"[external_bookings] upsert_user_bookings failed for userId={userId}: {e}")
+
+
+def delete_user_bookings(userId: int) -> None:
+    """Remove all booking records for a user."""
+    try:
+        external_event_bookings_collection.delete_many({"userId": userId})
+    except Exception as e:
+        logging.error(f"[external_bookings] delete_user_bookings failed for userId={userId}: {e}")
+
+
+def delete_booking(userId: int, eventId: int) -> None:
+    """Remove a single booking record."""
+    try:
+        external_event_bookings_collection.delete_one({"userId": userId, "eventId": eventId})
+    except Exception as e:
+        logging.error(f"[external_bookings] delete_booking failed userId={userId} eventId={eventId}: {e}")
+
+
+def add_booking(userId: int, eventId: int) -> None:
+    """Insert a single booking record (idempotent)."""
+    try:
+        external_event_bookings_collection.update_one(
+            {"userId": userId, "eventId": eventId},
+            {"$setOnInsert": {"userId": userId, "eventId": eventId}},
+            upsert=True,
+        )
+    except Exception as e:
+        logging.error(f"[external_bookings] add_booking failed userId={userId} eventId={eventId}: {e}")
+
+
+def get_bookings_by_event_ids(event_ids: List[int]) -> Dict[int, Set[int]]:
+    """Return {eventId: set(userIds)} for all given eventIds."""
+    if not event_ids:
+        return {}
+    try:
+        result: Dict[int, Set[int]] = {}
+        for doc in external_event_bookings_collection.find({"eventId": {"$in": event_ids}}):
+            result.setdefault(doc["eventId"], set()).add(doc["userId"])
+        return result
+    except Exception as e:
+        logging.error(f"[external_bookings] get_bookings_by_event_ids failed: {e}")
+        return {}

--- a/backend/v1/db/models/external_events.py
+++ b/backend/v1/db/models/external_events.py
@@ -50,3 +50,7 @@ class ExternalEvent(BaseModel):
     eventId: int
     date: date
     time: time
+
+class ExternalEventBooking(BaseModel):
+    userId: int
+    eventId: int

--- a/backend/v1/db/mongo.py
+++ b/backend/v1/db/mongo.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel
 from v1.db.models.tokenstorage import TokenStorage
 from v1.db.models.user import User
 from v1.user_events.user_events_model import UserEvent
-from v1.db.models.external_events import ExternalEventDetails, ExternalRoot
+from v1.db.models.external_events import ExternalEventDetails, ExternalRoot, ExternalEventBooking
 from v1.db.review_users import review_users
 
 logging.basicConfig(level=logging.INFO)
@@ -24,6 +24,7 @@ tokenstorage_collection = db[get_collection_name(TokenStorage)]
 user_event_collection = db[get_collection_name(UserEvent)]
 external_event_collection = db[get_collection_name(ExternalEventDetails)]
 external_root_collection = db[get_collection_name(ExternalRoot)]
+external_event_bookings_collection = db[get_collection_name(ExternalEventBooking)]
 
 def initialize_db():
 
@@ -41,6 +42,12 @@ def initialize_db():
 
         initialize_collection(ExternalEventDetails, db)
         external_event_collection.create_index("eventId", unique=True)
+
+        initialize_collection(ExternalEventBooking, db)
+        external_event_bookings_collection.create_index(
+            [("userId", 1), ("eventId", 1)], unique=True
+        )
+        external_event_bookings_collection.create_index("eventId")
 
         initialize_collection(ExternalRoot, db)
 

--- a/backend/v1/events/events_mappers.py
+++ b/backend/v1/events/events_mappers.py
@@ -58,7 +58,12 @@ def _utc_now() -> datetime:
     return get_current_time().replace(tzinfo=None)
 
 
-def map_external_event(details: ExternalEventDetails, current_user_id: int, booked_ids: Set[int]) -> Optional[Event]:
+def map_external_event(
+    details: ExternalEventDetails,
+    current_user_id: int,
+    booked_ids: Set[int],
+    attendee_user_ids: Optional[Set[int]] = None,
+) -> Optional[Event]:
     # eventDate already combined in event_api.get_external_event_details
     if not details.eventDate:
         logging.warning(f"External event missing eventDate: {details.eventId}")
@@ -134,7 +139,11 @@ def map_external_event(details: ExternalEventDetails, current_user_id: int, book
             bookingStart=booking_start,
             bookingEnd=booking_end,
             showAttendees=ShowAttendees.all if details.showBooked else ShowAttendees.none,
-            attendees=[],  # hardcoded empty — external API does not expose attendee list
+            attendees=(
+                [EventAttendee(userId=uid) for uid in attendee_user_ids]
+                if attendee_user_ids is not None
+                else []
+            ),
             queue=[],
             maxAttendees=(details.booked + details.stock) if details.isLimited else None,
             price=float(details.price) if not details.isFree else 0.0,

--- a/backend/v1/events/events_service.py
+++ b/backend/v1/events/events_service.py
@@ -20,6 +20,7 @@ from v1.user_events.user_events_db import (
 from v1.user_events.user_events_model import UserEvent, Host as UEHost, Attendee as UEAttendee, Location as UELocation
 from v1.utilities import get_current_time
 from v1.db.users import get_users_by_ids
+from v1.db.external_bookings import get_bookings_by_event_ids
 from v1.db.models.user import PrivacySetting, viewer_can_see, effective_setting
 from fastapi import HTTPException
 
@@ -87,9 +88,30 @@ def list_unified_events(
         logging.error(f"Failed to fetch all external events: {e}")
         external_events_details = []
 
+    # Bulk-fetch attendee user IDs for all external events in one DB query
+    try:
+        all_event_ids = [d.eventId for d in external_events_details]
+        bookings_by_event = get_bookings_by_event_ids(all_event_ids)
+    except Exception as e:
+        logging.error(f"Failed to fetch external event bookings: {e}")
+        bookings_by_event = {}
+
     external_events: List[Event] = []
     for d in external_events_details:
-        mapped = map_external_event(d, current_user_id, booked_ids)
+        # Determine if attendees should be exposed for this event
+        admin_ids: List[int] = []
+        if d.admins:
+            for a in d.admins:
+                try:
+                    admin_ids.append(int(a))
+                except (ValueError, TypeError):
+                    pass
+        user_is_admin = current_user_id in admin_ids
+        should_show_attendees = d.showBooked or user_is_admin
+
+        attendee_user_ids = bookings_by_event.get(d.eventId) if should_show_attendees else None
+
+        mapped = map_external_event(d, current_user_id, booked_ids, attendee_user_ids)
         if mapped:
             external_events.append(_filter_event_attendees(mapped, current_user))
 

--- a/backend/v1/events/events_service.py
+++ b/backend/v1/events/events_service.py
@@ -20,7 +20,7 @@ from v1.user_events.user_events_db import (
 from v1.user_events.user_events_model import UserEvent, Host as UEHost, Attendee as UEAttendee, Location as UELocation
 from v1.utilities import get_current_time
 from v1.db.users import get_users_by_ids
-from v1.db.external_bookings import get_bookings_by_event_ids
+from v1.db.external_bookings import get_bookings_by_event_ids, add_booking, delete_booking
 from v1.db.models.user import PrivacySetting, viewer_can_see, effective_setting
 from fastapi import HTTPException
 
@@ -276,7 +276,12 @@ def _attend_external_event(unified_event_id: str, current_user: dict) -> Event:
         # For external events, "attending" means booking
         result = book_external_event(current_user["userId"], event_id)
         logging.info(f"Successfully booked external event {event_id} for user {current_user['userId']}")
-        
+        # Sync booking to local cache
+        try:
+            add_booking(userId=current_user["userId"], eventId=event_id)
+        except Exception as e:
+            logging.error(f"Failed to sync booking to cache for userId={current_user['userId']} eventId={event_id}: {e}")
+
         # Try to find the event in our stored external events to return proper data
         try:
             external_events_details = get_all_stored_external_event_details()
@@ -364,6 +369,11 @@ def _unattend_external_event(unified_event_id: str, current_user: dict) -> dict:
         # For external events, "unattending" means unbooking
         result = unbook_external_event(current_user["userId"], event_id)
         logging.info(f"Successfully unbooked external event {event_id} for user {current_user['userId']}")
+        # Sync booking removal to local cache
+        try:
+            delete_booking(userId=current_user["userId"], eventId=event_id)
+        except Exception as e:
+            logging.error(f"Failed to sync booking removal for userId={current_user['userId']} eventId={event_id}: {e}")
         return {"message": "Successfully unattended event", "result": result}
     except HTTPException:
         raise

--- a/backend/v1/jobs/refresh_events.py
+++ b/backend/v1/jobs/refresh_events.py
@@ -2,7 +2,13 @@ from v1.db.external_events import (
     clean_external_events,
     get_stored_external_event_details,
 )
-from v1.external.event_api import get_external_root, get_external_event_details
+from v1.external.event_api import (
+    get_external_root,
+    get_external_event_details,
+    get_booked_external_events,
+)
+from v1.db.external_bookings import upsert_user_bookings, delete_user_bookings
+from v1.db.mongo import tokenstorage_collection
 import logging
 
 def refresh_external_events():
@@ -16,7 +22,7 @@ def refresh_external_events():
         date_external_events = get_external_event_details(root.restUrl, date)
         if date_external_events:
             all_external_events.extend(date_external_events)
-    
+
     # Remove external events that are not in the list of all_external_events
     clean_external_events(keeping=all_external_events)
 
@@ -29,3 +35,24 @@ def refresh_external_events():
         if not stored_event:
             logging.error(f"Event {event_id} not found in the database after cleaning.")
             continue
+
+    # Refresh per-user booking cache after events are updated
+    refresh_external_bookings()
+
+
+def refresh_external_bookings():
+    """Refresh the external_event_bookings collection for all users with stored tokens."""
+    try:
+        user_ids = [doc["userId"] for doc in tokenstorage_collection.find({}, {"userId": 1})]
+    except Exception as e:
+        logging.error(f"[refresh_external_bookings] Failed to fetch token holders: {e}")
+        return
+
+    logging.info(f"[refresh_external_bookings] Refreshing bookings for {len(user_ids)} users")
+    for user_id in user_ids:
+        try:
+            booked = get_booked_external_events(user_id)
+            event_ids = [e.eventId for e in booked]
+            upsert_user_bookings(userId=user_id, event_ids=event_ids)
+        except Exception as e:
+            logging.warning(f"[refresh_external_bookings] Skipping userId={user_id}: {e}")

--- a/docs/superpowers/plans/2026-05-15-event-participation.md
+++ b/docs/superpowers/plans/2026-05-15-event-participation.md
@@ -1,0 +1,733 @@
+# Event Participation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use subagent-driven-development (recommended) or executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Populate the `attendees` field on unified external events so the existing frontend attendee list renders real data instead of always showing empty.
+
+**Architecture:** A new MongoDB collection `external_event_bookings` caches which internal userIds are booked into which external eventIds. It is populated by the background refresh job (iterates all token-holders) and updated immediately on book/unbook. `map_external_event` receives a set of attendee IDs and uses them when `showBooked=true` or the current user is admin.
+
+**Tech Stack:** Python 3, FastAPI, Pydantic v2, PyMongo, APScheduler, pytest
+
+---
+
+## File Map
+
+| Action | File | Purpose |
+|---|---|---|
+| Modify | `backend/v1/db/models/external_events.py` | Add `ExternalEventBooking` Pydantic model |
+| Modify | `backend/v1/db/mongo.py` | Register `external_event_bookings_collection` + index |
+| Create | `backend/v1/db/external_bookings.py` | CRUD: upsert, delete, bulk lookup by eventId |
+| Modify | `backend/v1/events/events_mappers.py` | Add `attendee_user_ids` param to `map_external_event` |
+| Modify | `backend/v1/events/events_service.py` | Fetch attendees in `list_unified_events`; sync on book/unbook |
+| Modify | `backend/v1/jobs/refresh_events.py` | Add `refresh_external_bookings()` call |
+| Modify | `backend/v1/jobs/scheduler.py` | (no change needed — refresh_events already scheduled) |
+| Modify | `backend/__tests__/unified_events-test.py` | Tests for new attendee propagation |
+
+---
+
+### Task 1: Add `ExternalEventBooking` model and register collection
+
+**Files:**
+- Modify: `backend/v1/db/models/external_events.py`
+- Modify: `backend/v1/db/mongo.py`
+
+- [ ] **Step 1: Add the model**
+
+Open `backend/v1/db/models/external_events.py` and append at the end:
+
+```python
+class ExternalEventBooking(BaseModel):
+    userId: int
+    eventId: int
+```
+
+- [ ] **Step 2: Register collection in mongo.py**
+
+Open `backend/v1/db/mongo.py`. Add the import and collection after the existing ones.
+
+After:
+```python
+from v1.db.models.external_events import ExternalEventDetails, ExternalRoot
+```
+Change to:
+```python
+from v1.db.models.external_events import ExternalEventDetails, ExternalRoot, ExternalEventBooking
+```
+
+After the line:
+```python
+external_root_collection = db[get_collection_name(ExternalRoot)]
+```
+Add:
+```python
+external_event_bookings_collection = db[get_collection_name(ExternalEventBooking)]
+```
+
+Inside `initialize_db()`, after the `external_event_collection.create_index("eventId", unique=True)` line, add:
+```python
+        initialize_collection(ExternalEventBooking, db)
+        external_event_bookings_collection.create_index(
+            [("userId", 1), ("eventId", 1)], unique=True
+        )
+        external_event_bookings_collection.create_index("eventId")
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Volumes/Projects/swagapp
+git add backend/v1/db/models/external_events.py backend/v1/db/mongo.py
+git commit -m "feat(db): add ExternalEventBooking model and collection"
+```
+
+---
+
+### Task 2: Create `external_bookings.py` CRUD module
+
+**Files:**
+- Create: `backend/v1/db/external_bookings.py`
+- Test: `backend/__tests__/unified_events-test.py` (new test section)
+
+- [ ] **Step 1: Write failing tests**
+
+Open `backend/__tests__/unified_events-test.py` and add these tests at the end of the file:
+
+```python
+# ── ExternalBookings CRUD tests ─────────────────────────────────────────────
+
+def test_upsert_and_get_bookings_by_event(monkeypatch):
+    """upsert_user_bookings stores pairs; get_bookings_by_event_ids groups by eventId."""
+    from v1.db import external_bookings as eb
+
+    stored = []
+
+    def fake_bulk_write(ops, ordered=False):
+        for op in ops:
+            doc = op._doc["$setOnInsert"] if "$setOnInsert" in op._doc else op._doc
+            # simplify: track what was upserted
+            stored.append(op._filter)
+
+    class FakeCol:
+        def bulk_write(self, ops, ordered=False):
+            fake_bulk_write(ops, ordered)
+        def find(self, query):
+            if query == {"eventId": {"$in": [10, 20]}}:
+                return [
+                    {"userId": 1, "eventId": 10},
+                    {"userId": 2, "eventId": 10},
+                    {"userId": 3, "eventId": 20},
+                ]
+            return []
+
+    monkeypatch.setattr(eb, "external_event_bookings_collection", FakeCol())
+
+    result = eb.get_bookings_by_event_ids([10, 20])
+    assert set(result[10]) == {1, 2}
+    assert set(result[20]) == {3}
+    assert eb.get_bookings_by_event_ids([]) == {}
+
+
+def test_delete_user_bookings(monkeypatch):
+    from v1.db import external_bookings as eb
+
+    deleted_filter = []
+
+    class FakeCol:
+        def delete_many(self, f):
+            deleted_filter.append(f)
+
+    monkeypatch.setattr(eb, "external_event_bookings_collection", FakeCol())
+    eb.delete_user_bookings(userId=5)
+    assert deleted_filter == [{"userId": 5}]
+
+
+def test_delete_booking(monkeypatch):
+    from v1.db import external_bookings as eb
+
+    deleted = []
+
+    class FakeCol:
+        def delete_one(self, f):
+            deleted.append(f)
+
+    monkeypatch.setattr(eb, "external_event_bookings_collection", FakeCol())
+    eb.delete_booking(userId=5, eventId=99)
+    assert deleted == [{"userId": 5, "eventId": 99}]
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+cd /Volumes/Projects/swagapp/backend
+python -m pytest __tests__/unified_events-test.py::test_upsert_and_get_bookings_by_event __tests__/unified_events-test.py::test_delete_user_bookings __tests__/unified_events-test.py::test_delete_booking -v 2>&1 | tail -20
+```
+
+Expected: `ModuleNotFoundError` or `ImportError` — `external_bookings` does not exist yet.
+
+- [ ] **Step 3: Create the module**
+
+Create `backend/v1/db/external_bookings.py`:
+
+```python
+from __future__ import annotations
+import logging
+from typing import Dict, List, Set
+from pymongo import UpdateOne
+from v1.db.mongo import external_event_bookings_collection
+
+
+def upsert_user_bookings(userId: int, event_ids: List[int]) -> None:
+    """Replace all bookings for userId with the given event_ids."""
+    if not event_ids:
+        delete_user_bookings(userId)
+        return
+    ops = [
+        UpdateOne(
+            {"userId": userId, "eventId": eid},
+            {"$setOnInsert": {"userId": userId, "eventId": eid}},
+            upsert=True,
+        )
+        for eid in event_ids
+    ]
+    try:
+        external_event_bookings_collection.bulk_write(ops, ordered=False)
+        # Remove stale entries (events no longer booked)
+        external_event_bookings_collection.delete_many(
+            {"userId": userId, "eventId": {"$nin": event_ids}}
+        )
+    except Exception as e:
+        logging.error(f"[external_bookings] upsert_user_bookings failed for userId={userId}: {e}")
+
+
+def delete_user_bookings(userId: int) -> None:
+    """Remove all booking records for a user (e.g. token expired, all unbooked)."""
+    try:
+        external_event_bookings_collection.delete_many({"userId": userId})
+    except Exception as e:
+        logging.error(f"[external_bookings] delete_user_bookings failed for userId={userId}: {e}")
+
+
+def delete_booking(userId: int, eventId: int) -> None:
+    """Remove a single booking record."""
+    try:
+        external_event_bookings_collection.delete_one({"userId": userId, "eventId": eventId})
+    except Exception as e:
+        logging.error(f"[external_bookings] delete_booking failed userId={userId} eventId={eventId}: {e}")
+
+
+def add_booking(userId: int, eventId: int) -> None:
+    """Insert a single booking record (idempotent)."""
+    try:
+        external_event_bookings_collection.update_one(
+            {"userId": userId, "eventId": eventId},
+            {"$setOnInsert": {"userId": userId, "eventId": eventId}},
+            upsert=True,
+        )
+    except Exception as e:
+        logging.error(f"[external_bookings] add_booking failed userId={userId} eventId={eventId}: {e}")
+
+
+def get_bookings_by_event_ids(event_ids: List[int]) -> Dict[int, Set[int]]:
+    """Return {eventId: set(userIds)} for all given eventIds."""
+    if not event_ids:
+        return {}
+    try:
+        result: Dict[int, Set[int]] = {}
+        for doc in external_event_bookings_collection.find({"eventId": {"$in": event_ids}}):
+            result.setdefault(doc["eventId"], set()).add(doc["userId"])
+        return result
+    except Exception as e:
+        logging.error(f"[external_bookings] get_bookings_by_event_ids failed: {e}")
+        return {}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd /Volumes/Projects/swagapp/backend
+python -m pytest __tests__/unified_events-test.py::test_upsert_and_get_bookings_by_event __tests__/unified_events-test.py::test_delete_user_bookings __tests__/unified_events-test.py::test_delete_booking -v 2>&1 | tail -20
+```
+
+Expected: 3 PASSED.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Volumes/Projects/swagapp
+git add backend/v1/db/external_bookings.py backend/__tests__/unified_events-test.py
+git commit -m "feat(db): add external_bookings CRUD module with tests"
+```
+
+---
+
+### Task 3: Update `map_external_event` to accept attendee IDs
+
+**Files:**
+- Modify: `backend/v1/events/events_mappers.py`
+- Test: `backend/__tests__/unified_events-test.py`
+
+- [ ] **Step 1: Write failing tests**
+
+In `backend/__tests__/unified_events-test.py`, add:
+
+```python
+# ── map_external_event attendee tests ────────────────────────────────────────
+
+def test_map_external_event_with_attendee_ids():
+    ext = make_external_event(200, booked=2)
+    mapped = map_external_event(ext, current_user_id=1, booked_ids={200}, attendee_user_ids={1, 7})
+    assert {a.userId for a in mapped.attendees} == {1, 7}
+
+
+def test_map_external_event_no_attendee_ids_gives_empty():
+    ext = make_external_event(201)
+    mapped = map_external_event(ext, current_user_id=1, booked_ids=set(), attendee_user_ids=None)
+    assert mapped.attendees == []
+
+
+def test_map_external_event_empty_set_gives_empty():
+    ext = make_external_event(202)
+    mapped = map_external_event(ext, current_user_id=1, booked_ids=set(), attendee_user_ids=set())
+    assert mapped.attendees == []
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+cd /Volumes/Projects/swagapp/backend
+python -m pytest __tests__/unified_events-test.py::test_map_external_event_with_attendee_ids __tests__/unified_events-test.py::test_map_external_event_no_attendee_ids_gives_empty __tests__/unified_events-test.py::test_map_external_event_empty_set_gives_empty -v 2>&1 | tail -20
+```
+
+Expected: TypeError — `map_external_event()` got unexpected keyword argument `attendee_user_ids`.
+
+- [ ] **Step 3: Update `map_external_event` signature and usage**
+
+In `backend/v1/events/events_mappers.py`, change the function signature from:
+
+```python
+def map_external_event(details: ExternalEventDetails, current_user_id: int, booked_ids: Set[int]) -> Optional[Event]:
+```
+
+to:
+
+```python
+def map_external_event(
+    details: ExternalEventDetails,
+    current_user_id: int,
+    booked_ids: Set[int],
+    attendee_user_ids: Optional[Set[int]] = None,
+) -> Optional[Event]:
+```
+
+Also add `Optional` and `Set` to the imports at the top if not already present:
+```python
+from typing import Optional, Set
+```
+
+Inside the function body, replace the line:
+```python
+            attendees=[],  # hardcoded empty — external API does not expose attendee list
+```
+with:
+```python
+            attendees=(
+                [EventAttendee(userId=uid) for uid in attendee_user_ids]
+                if attendee_user_ids is not None
+                else []
+            ),
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd /Volumes/Projects/swagapp/backend
+python -m pytest __tests__/unified_events-test.py -v 2>&1 | tail -30
+```
+
+Expected: all previously passing tests still PASS, plus 3 new ones.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Volumes/Projects/swagapp
+git add backend/v1/events/events_mappers.py backend/__tests__/unified_events-test.py
+git commit -m "feat(events): map_external_event accepts optional attendee_user_ids"
+```
+
+---
+
+### Task 4: Wire attendee lookup into `list_unified_events`
+
+**Files:**
+- Modify: `backend/v1/events/events_service.py`
+- Test: `backend/__tests__/unified_events-test.py`
+
+- [ ] **Step 1: Write a failing integration test**
+
+Add to `backend/__tests__/unified_events-test.py`:
+
+```python
+# ── list_unified_events attendee propagation ─────────────────────────────────
+
+def test_list_unified_events_populates_attendees_when_show_booked(monkeypatch):
+    import v1.events.events_service as svc
+
+    ext = make_external_event(300, booked=1)
+    ext.showBooked = True
+
+    monkeypatch.setattr(svc, "get_booked_external_events", lambda uid: [])
+    monkeypatch.setattr(svc, "get_all_stored_external_event_details", lambda: [ext])
+    monkeypatch.setattr(svc, "get_safe_user_events_since", lambda since: [])
+    monkeypatch.setattr(svc, "get_users_by_ids", lambda ids: [])
+    # Simulate bookings DB returning userId=42 for eventId=300
+    monkeypatch.setattr(svc, "get_bookings_by_event_ids", lambda ids: {300: {42}})
+
+    current_user = {"userId": 1, "settings": {}}
+    events = svc.list_unified_events(current_user)
+    ext_events = [e for e in events if e.id == "ext300"]
+    assert len(ext_events) == 1
+    assert {a.userId for a in ext_events[0].attendees} == {42}
+
+
+def test_list_unified_events_no_attendees_when_show_booked_false_and_not_admin(monkeypatch):
+    import v1.events.events_service as svc
+
+    ext = make_external_event(301, booked=5)
+    ext.showBooked = False
+    ext.admins = None
+
+    monkeypatch.setattr(svc, "get_booked_external_events", lambda uid: [])
+    monkeypatch.setattr(svc, "get_all_stored_external_event_details", lambda: [ext])
+    monkeypatch.setattr(svc, "get_safe_user_events_since", lambda since: [])
+    monkeypatch.setattr(svc, "get_users_by_ids", lambda ids: [])
+    monkeypatch.setattr(svc, "get_bookings_by_event_ids", lambda ids: {301: {42}})
+
+    current_user = {"userId": 1, "settings": {}}
+    events = svc.list_unified_events(current_user)
+    ext_events = [e for e in events if e.id == "ext301"]
+    assert len(ext_events) == 1
+    assert ext_events[0].attendees == []
+
+
+def test_list_unified_events_admin_sees_attendees_even_if_show_booked_false(monkeypatch):
+    import v1.events.events_service as svc
+
+    ext = make_external_event(302, booked=2)
+    ext.showBooked = False
+    ext.admins = ["99"]  # userId 99 is admin
+
+    monkeypatch.setattr(svc, "get_booked_external_events", lambda uid: [])
+    monkeypatch.setattr(svc, "get_all_stored_external_event_details", lambda: [ext])
+    monkeypatch.setattr(svc, "get_safe_user_events_since", lambda since: [])
+    monkeypatch.setattr(svc, "get_users_by_ids", lambda ids: [])
+    monkeypatch.setattr(svc, "get_bookings_by_event_ids", lambda ids: {302: {7, 8}})
+
+    current_user = {"userId": 99, "settings": {}}
+    events = svc.list_unified_events(current_user)
+    ext_events = [e for e in events if e.id == "ext302"]
+    assert len(ext_events) == 1
+    assert {a.userId for a in ext_events[0].attendees} == {7, 8}
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+cd /Volumes/Projects/swagapp/backend
+python -m pytest __tests__/unified_events-test.py::test_list_unified_events_populates_attendees_when_show_booked __tests__/unified_events-test.py::test_list_unified_events_no_attendees_when_show_booked_false_and_not_admin __tests__/unified_events-test.py::test_list_unified_events_admin_sees_attendees_even_if_show_booked_false -v 2>&1 | tail -20
+```
+
+Expected: AttributeError — `module has no attribute 'get_bookings_by_event_ids'` (not imported yet).
+
+- [ ] **Step 3: Update `events_service.py`**
+
+At the top of `backend/v1/events/events_service.py`, add this import after the existing imports:
+
+```python
+from v1.db.external_bookings import get_bookings_by_event_ids
+```
+
+Inside `list_unified_events`, find the section after `external_events_details` is fetched:
+
+```python
+    external_events: List[Event] = []
+    for d in external_events_details:
+        mapped = map_external_event(d, current_user_id, booked_ids)
+        if mapped:
+            external_events.append(_filter_event_attendees(mapped, current_user))
+```
+
+Replace with:
+
+```python
+    # Bulk-fetch attendee user IDs for all external events in one DB query
+    try:
+        all_event_ids = [d.eventId for d in external_events_details]
+        bookings_by_event = get_bookings_by_event_ids(all_event_ids)
+    except Exception as e:
+        logging.error(f"Failed to fetch external event bookings: {e}")
+        bookings_by_event = {}
+
+    external_events: List[Event] = []
+    for d in external_events_details:
+        # Determine if attendees should be exposed for this event
+        admin_ids: List[int] = []
+        if d.admins:
+            for a in d.admins:
+                try:
+                    admin_ids.append(int(a))
+                except (ValueError, TypeError):
+                    pass
+        user_is_admin = current_user_id in admin_ids
+        should_show_attendees = d.showBooked or user_is_admin
+
+        attendee_user_ids = bookings_by_event.get(d.eventId) if should_show_attendees else None
+
+        mapped = map_external_event(d, current_user_id, booked_ids, attendee_user_ids)
+        if mapped:
+            external_events.append(_filter_event_attendees(mapped, current_user))
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd /Volumes/Projects/swagapp/backend
+python -m pytest __tests__/unified_events-test.py -v 2>&1 | tail -30
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Volumes/Projects/swagapp
+git add backend/v1/events/events_service.py backend/__tests__/unified_events-test.py
+git commit -m "feat(events): populate external event attendees from bookings collection"
+```
+
+---
+
+### Task 5: Sync bookings collection on book/unbook
+
+**Files:**
+- Modify: `backend/v1/events/events_service.py`
+- Test: `backend/__tests__/unified_events-test.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `backend/__tests__/unified_events-test.py`:
+
+```python
+# ── book/unbook booking sync tests ──────────────────────────────────────────
+
+def test_attend_external_event_syncs_booking(monkeypatch):
+    import v1.events.events_service as svc
+    from v1.db.models.external_events import ExternalEventDetails as EED
+
+    ext = make_external_event(400)
+    added = []
+
+    monkeypatch.setattr(svc, "book_external_event", lambda uid, eid: {"status": "OK"})
+    monkeypatch.setattr(svc, "get_all_stored_external_event_details", lambda: [ext])
+    monkeypatch.setattr(svc, "get_booked_external_events", lambda uid: [])
+    monkeypatch.setattr(svc, "add_booking", lambda userId, eventId: added.append((userId, eventId)))
+
+    current_user = {"userId": 5, "settings": {}}
+    svc._attend_external_event("ext400", current_user)
+    assert (5, 400) in added
+
+
+def test_unattend_external_event_syncs_booking(monkeypatch):
+    import v1.events.events_service as svc
+
+    deleted = []
+    monkeypatch.setattr(svc, "unbook_external_event", lambda uid, eid: {"status": "OK"})
+    monkeypatch.setattr(svc, "delete_booking", lambda userId, eventId: deleted.append((userId, eventId)))
+
+    current_user = {"userId": 5, "settings": {}}
+    svc._unattend_external_event("ext400", current_user)
+    assert (5, 400) in deleted
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+cd /Volumes/Projects/swagapp/backend
+python -m pytest __tests__/unified_events-test.py::test_attend_external_event_syncs_booking __tests__/unified_events-test.py::test_unattend_external_event_syncs_booking -v 2>&1 | tail -20
+```
+
+Expected: AttributeError — `module has no attribute 'add_booking'`.
+
+- [ ] **Step 3: Import add_booking and delete_booking in events_service.py**
+
+In `backend/v1/events/events_service.py`, update the external_bookings import line from:
+
+```python
+from v1.db.external_bookings import get_bookings_by_event_ids
+```
+
+to:
+
+```python
+from v1.db.external_bookings import get_bookings_by_event_ids, add_booking, delete_booking
+```
+
+- [ ] **Step 4: Sync add_booking in `_attend_external_event`**
+
+In `backend/v1/events/events_service.py`, find `_attend_external_event`. After the line:
+
+```python
+        result = book_external_event(current_user["userId"], event_id)
+        logging.info(f"Successfully booked external event {event_id} for user {current_user['userId']}")
+```
+
+Add:
+
+```python
+        # Sync booking to local cache
+        try:
+            add_booking(userId=current_user["userId"], eventId=event_id)
+        except Exception as e:
+            logging.error(f"Failed to sync booking to cache for userId={current_user['userId']} eventId={event_id}: {e}")
+```
+
+- [ ] **Step 5: Sync delete_booking in `_unattend_external_event`**
+
+In `backend/v1/events/events_service.py`, find `_unattend_external_event`. After the line:
+
+```python
+        result = unbook_external_event(current_user["userId"], event_id)
+        logging.info(f"Successfully unbooked external event {event_id} for user {current_user['userId']}")
+```
+
+Add:
+
+```python
+        # Sync booking removal to local cache
+        try:
+            delete_booking(userId=current_user["userId"], eventId=event_id)
+        except Exception as e:
+            logging.error(f"Failed to sync booking removal for userId={current_user['userId']} eventId={event_id}: {e}")
+```
+
+- [ ] **Step 6: Run all tests**
+
+```bash
+cd /Volumes/Projects/swagapp/backend
+python -m pytest __tests__/unified_events-test.py -v 2>&1 | tail -30
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Volumes/Projects/swagapp
+git add backend/v1/events/events_service.py backend/__tests__/unified_events-test.py
+git commit -m "feat(events): sync external bookings cache on attend/unattend"
+```
+
+---
+
+### Task 6: Background refresh of all users' bookings
+
+**Files:**
+- Modify: `backend/v1/jobs/refresh_events.py`
+- Test: manual (no pure-unit test possible without mocking all external + DB calls)
+
+- [ ] **Step 1: Add `refresh_external_bookings` function to `refresh_events.py`**
+
+Open `backend/v1/jobs/refresh_events.py`. Add imports at the top:
+
+```python
+import logging
+from v1.db.external_bookings import upsert_user_bookings, delete_user_bookings
+from v1.db.mongo import tokenstorage_collection
+from v1.external.event_api import get_booked_external_events
+```
+
+Then add the function after `refresh_external_events`:
+
+```python
+def refresh_external_bookings():
+    """Refresh the external_event_bookings collection for all users with stored tokens."""
+    try:
+        user_ids = [doc["userId"] for doc in tokenstorage_collection.find({}, {"userId": 1})]
+    except Exception as e:
+        logging.error(f"[refresh_external_bookings] Failed to fetch token holders: {e}")
+        return
+
+    logging.info(f"[refresh_external_bookings] Refreshing bookings for {len(user_ids)} users")
+    for user_id in user_ids:
+        try:
+            booked = get_booked_external_events(user_id)
+            event_ids = [e.eventId for e in booked]
+            upsert_user_bookings(userId=user_id, event_ids=event_ids)
+        except Exception as e:
+            logging.warning(f"[refresh_external_bookings] Skipping userId={user_id}: {e}")
+```
+
+- [ ] **Step 2: Call `refresh_external_bookings` from `refresh_external_events`**
+
+At the end of the `refresh_external_events` function in `backend/v1/jobs/refresh_events.py`, add:
+
+```python
+    # Refresh per-user booking cache after events are updated
+    refresh_external_bookings()
+```
+
+The full `refresh_external_events` function should end with:
+```python
+    for event in all_external_events:
+        event_id = event.eventId
+        stored_event = get_stored_external_event_details(event_ids=[event_id])
+        if not stored_event:
+            logging.error(f"Event {event_id} not found in the database after cleaning.")
+            continue
+
+    # Refresh per-user booking cache after events are updated
+    refresh_external_bookings()
+```
+
+- [ ] **Step 3: Run full test suite to confirm no regressions**
+
+```bash
+cd /Volumes/Projects/swagapp/backend
+python -m pytest __tests__/ -v 2>&1 | tail -40
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Volumes/Projects/swagapp
+git add backend/v1/jobs/refresh_events.py
+git commit -m "feat(jobs): refresh external event bookings for all users in background job"
+```
+
+---
+
+### Task 7: Push and verify
+
+- [ ] **Step 1: Run full test suite one final time**
+
+```bash
+cd /Volumes/Projects/swagapp/backend
+python -m pytest __tests__/ -v 2>&1 | tail -40
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 2: Push**
+
+```bash
+cd /Volumes/Projects/swagapp
+git pull --rebase
+git push
+```
+
+- [ ] **Step 3: Close the task**
+
+```bash
+grit tasks close swagapp-xi5pz --reason="External event attendees now populated from cached bookings collection. Background job refreshes all users. Book/unbook syncs immediately. Frontend was already wired up."
+```

--- a/docs/superpowers/specs/2026-05-15-event-participation-design.md
+++ b/docs/superpowers/specs/2026-05-15-event-participation-design.md
@@ -1,0 +1,127 @@
+# Event Participation: Attendees on External Events
+
+**Task**: swagapp-xi5pz (P1)
+
+## Decisions
+
+1. **New MongoDB collection** (`external_event_bookings`) stores `{userId, eventId}` pairs — we don't have this data today; we derive it by iterating all users with stored tokens.
+2. **Backend-only change** — the frontend (`UnifiedEventCard` → `useEventUsers` → attendees `UserList`) is already wired up and works correctly once the API returns non-empty `attendees`.
+3. **Two triggers for populating attendees on external events**: (a) `showBooked=true` on the raw external event, OR (b) current user is admin of the event (`current_user_id in admin_ids`). The `showAttendees` field on the unified event is already set from `showBooked`; admin override is added in `list_unified_events`.
+4. **Background refresh updates bookings** for all users with stored tokens. On-demand book/unbook also syncs immediately.
+5. **Privacy filter still applies** — `_filter_event_attendees` in `events_service.py` filters based on users' `show_attendance` privacy settings. External attendees get the same filter.
+
+## Goal
+
+Populate the `attendees` field on unified external events when:
+- `showAttendees == 'all'` (mapped from `showBooked=true`), OR
+- Current user is admin/host of the event
+
+Currently `attendees=[]` is hardcoded for all external events in `events_mappers.py:137`.
+
+## Architecture
+
+### New collection: `external_event_bookings`
+
+```python
+class ExternalEventBooking(BaseModel):
+    userId: int
+    eventId: int  # raw external eventId
+```
+
+Indexed on `eventId` (fast lookup when building events list) and `userId` (fast per-user refresh).
+
+### Data flow
+
+```
+[Background job: refresh_external_bookings()]
+    ↓ iterate all users in tokenstorage_collection
+    ↓ call get_booked_external_events(userId) for each
+    ↓ upsert {userId, eventId} pairs into external_event_bookings
+    ↓ delete stale pairs for users where eventId no longer in their booked list
+
+[On book / unbook]
+    _attend_external_event  → insert {userId, eventId}
+    _unattend_external_event → delete {userId, eventId}
+
+[list_unified_events]
+    map_external_event(details, user_id, booked_ids, attendee_user_ids)
+        attendee_user_ids = lookup external_event_bookings by eventId
+        only passed when showBooked OR user is admin
+```
+
+### Files changed
+
+| File | Change |
+|---|---|
+| `backend/v1/db/models/external_events.py` | Add `ExternalEventBooking` model |
+| `backend/v1/db/mongo.py` | Register `external_event_bookings_collection` |
+| `backend/v1/db/external_bookings.py` | New: CRUD for `external_event_bookings` |
+| `backend/v1/jobs/refresh_events.py` | Add `refresh_external_bookings()` call after event refresh |
+| `backend/v1/events/events_mappers.py` | Add `attendee_user_ids: set[int]` param to `map_external_event` |
+| `backend/v1/events/events_service.py` | Fetch attendee IDs and pass to `map_external_event`; update book/unbook to sync |
+| `backend/__tests__/unified_events-test.py` | Add tests for attendees propagation |
+
+### `map_external_event` signature change
+
+```python
+def map_external_event(
+    details: ExternalEventDetails,
+    current_user_id: int,
+    booked_ids: Set[int],
+    attendee_user_ids: Set[int] | None = None,  # NEW
+) -> Optional[Event]:
+```
+
+When `attendee_user_ids` is provided (non-None), set `attendees=[EventAttendee(userId=uid) for uid in attendee_user_ids]`. Otherwise keep `[]`.
+
+### `list_unified_events` logic
+
+```python
+# After fetching all external event details:
+bookings_by_event = get_bookings_by_event_ids([d.eventId for d in external_events_details])
+
+for d in external_events_details:
+    admin_ids = [int(a) for a in (d.admins or []) if a.isdigit()]
+    user_is_admin = current_user_id in admin_ids
+    should_show_attendees = d.showBooked or user_is_admin
+    
+    attendee_ids = bookings_by_event.get(d.eventId) if should_show_attendees else None
+    mapped = map_external_event(d, current_user_id, booked_ids, attendee_ids)
+```
+
+## Error handling
+
+- `refresh_external_bookings` catches per-user failures and continues (same pattern as refresh_events job)
+- If `get_bookings_by_event_ids` fails in `list_unified_events`, log and fall back to empty attendees (not a hard error)
+- Book/unbook sync failures are logged but don't fail the booking itself
+
+## Tests
+
+1. `test_map_external_event_with_attendees` — verify attendee IDs appear in mapped event
+2. `test_map_external_event_no_attendees_when_show_booked_false` — verify empty attendees when not admin and showBooked=False
+3. `test_list_unified_events_populates_attendees_for_show_booked` — integration test with monkeypatched DB
+
+## Considered alternatives
+
+**A. Only show current user in their own attendees list**
+- Pro: No new collection, immediate with data we already have
+- Con: Useless for seeing who else is attending; doesn't scale
+- Rejected: The UI expectation is to show all attendees
+
+**B. Call external API on every request for each event**
+- Pro: Always fresh
+- Con: N×M API calls (events × users) per unified events request; not feasible
+- Rejected: Performance kill
+
+**C. Chosen: Cached bookings collection**
+- Fresh enough via background job
+- Immediate on book/unbook
+- One extra DB lookup per events request (single aggregation query)
+
+## Risks and mitigations
+
+- **Token expiry**: users whose token has expired are silently skipped in the refresh job; graceful degradation, their booking still removed on unbook
+- **Staleness**: refresh runs every 15 min (matches existing event refresh cadence); acceptable for attendance display
+- **External API completeness**: `get_booked_external_events` is not paginated in this external system (Mensa Sverige has O(10s) events per user); not a practical concern
+- **Privacy filter**: `_filter_event_attendees` calls `get_users_by_ids` and checks each user's `show_attendance` setting in our own user DB. External event attendees are our internal users (stored by `userId`), so the filter applies correctly
+- **Admin + showBooked=false**: intentional — an event admin (e.g. a host who set showBooked=false) legitimately needs to see who's coming to their event; this is standard event management behavior


### PR DESCRIPTION
## Summary

- New `external_event_bookings` MongoDB collection caches which internal userIds are booked into which external eventIds
- `map_external_event` now accepts `attendee_user_ids` instead of hardcoding `attendees=[]`
- `list_unified_events` bulk-fetches bookings and exposes attendees when `showBooked=true` or viewer is admin/host
- `_attend_external_event` / `_unattend_external_event` sync the cache immediately on book/unbook
- Background refresh job iterates all token-holders every 15 min to keep cache fresh
- Frontend unchanged — `UnifiedEventCard` → `useEventUsers` → attendee `UserList` was already wired up

Closes swagapp-xi5pz

## Test plan
- [ ] Backend: `python -m pytest backend/__tests__/unified_events-test.py -v` — all new tests pass
- [ ] External event with `showBooked=true`: attendees list renders in the app
- [ ] Admin of external event with `showBooked=false`: still sees attendees
- [ ] Non-admin, `showBooked=false`: attendees list empty
- [ ] Book an event → attendee appears immediately on re-fetch
- [ ] Unbook → attendee disappears