### PR TITLE
feat: migrate backend from MongoDB to PostgreSQL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ docs/backend: python-deps
 		)
 
 python-deps: .venv
-	@.venv/bin/pip install -r ./backend/requirements.txt
+	@.venv/bin/pip install -r ./backend/v1/requirements.txt
 
 .venv:
 	@echo "Ensuring virtualenv"

--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,0 +1,47 @@
+[alembic]
+# script_location is relative to this file (backend/)
+script_location = alembic
+
+# Read DATABASE_URL from environment — never hardcode credentials here.
+# Alembic will substitute %(DATABASE_URL)s from the environment if set,
+# but env.py overrides sqlalchemy.url directly, so this acts as a
+# documentation placeholder only.
+sqlalchemy.url =
+
+# Add backend/ to sys.path so `v1` package is importable
+prepend_sys_path = .
+path_separator = os
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,0 +1,95 @@
+"""
+Alembic migration environment.
+
+Workflow:
+  - Run from the backend/ directory (where alembic.ini lives).
+  - DATABASE_URL is read from the environment; no credentials are hardcoded.
+  - On first deploy against a DB created by the old create_all() call, the
+    startup code in database.py stamps the DB at head automatically, so
+    Alembic knows it's already fully up to date without re-running the
+    initial migration.
+  - To generate a new migration:
+        cd backend/
+        alembic revision --autogenerate -m "describe the change"
+  - To apply migrations:
+        cd backend/
+        alembic upgrade head
+  - To check current state:
+        cd backend/
+        alembic current
+"""
+
+import os
+import sys
+from logging.config import fileConfig
+
+from sqlalchemy import engine_from_config, pool
+
+from alembic import context
+
+# Make sure v1 package is importable when running alembic directly.
+# alembic.ini sets prepend_sys_path = . which adds backend/ to sys.path,
+# but we guard here as well for safety.
+_backend_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _backend_dir not in sys.path:
+    sys.path.insert(0, _backend_dir)
+
+# Import Base and all models so metadata is fully populated.
+from v1.db.database import Base  # noqa: E402
+import v1.db.tables  # noqa: E402, F401
+
+# this is the Alembic Config object, which provides access to the values
+# within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# Set the SQLAlchemy URL from the environment, overriding the placeholder
+# in alembic.ini.
+database_url = os.environ.get(
+    "DATABASE_URL",
+    "postgresql://swag:swag@postgres:5432/swag",
+)
+config.set_main_option("sqlalchemy.url", database_url)
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode (emit SQL to stdout, no connection)."""
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode (requires a live DB connection)."""
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -83,6 +83,8 @@ def run_migrations_online() -> None:
         context.configure(
             connection=connection,
             target_metadata=target_metadata,
+            compare_type=True,
+            compare_server_default=True,
         )
 
         with context.begin_transaction():

--- a/backend/alembic/script.py.mako
+++ b/backend/alembic/script.py.mako
@@ -1,0 +1,26 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/backend/alembic/versions/001_initial_schema.py
+++ b/backend/alembic/versions/001_initial_schema.py
@@ -1,0 +1,292 @@
+"""Initial schema — all tables from the original create_all() baseline.
+
+Revision ID: 001
+Revises:
+Create Date: 2026-05-15
+
+This migration represents the complete schema as it existed when Alembic was
+first introduced.  Existing databases that were created by Base.metadata.create_all()
+before Alembic was added should be *stamped* at this revision (alembic stamp head)
+rather than having this migration run, because the tables already exist.
+The startup code in database.py handles that bootstrap automatically.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "001"
+down_revision: Union[str, None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # ── users ─────────────────────────────────────────────────────────────────
+    op.create_table(
+        "users",
+        sa.Column("userId", sa.Integer(), nullable=False),
+        sa.Column("isMember", sa.Boolean(), nullable=False),
+        sa.Column("show_location", sa.String(), nullable=False),
+        sa.Column("show_profile", sa.String(), nullable=False),
+        sa.Column("show_email", sa.String(), nullable=False),
+        sa.Column("show_phone", sa.String(), nullable=False),
+        sa.Column("show_interests", sa.String(), nullable=False),
+        sa.Column("show_hometown", sa.String(), nullable=False),
+        sa.Column("show_birthdate", sa.String(), nullable=False),
+        sa.Column("show_gender", sa.String(), nullable=False),
+        sa.Column("show_sexuality", sa.String(), nullable=False),
+        sa.Column("show_relationship_style", sa.String(), nullable=False),
+        sa.Column("show_relationship_status", sa.String(), nullable=False),
+        sa.Column("show_social_vibes", sa.String(), nullable=False),
+        sa.Column("show_pronomen", sa.String(), nullable=False),
+        sa.Column("show_attendance", sa.String(), nullable=True),
+        sa.Column("location_update_interval_seconds", sa.Integer(), nullable=False),
+        sa.Column("events_refresh_interval_seconds", sa.Integer(), nullable=False),
+        sa.Column("background_location_updates", sa.Boolean(), nullable=False),
+        sa.Column("location_latitude", sa.Float(), nullable=True),
+        sa.Column("location_longitude", sa.Float(), nullable=True),
+        sa.Column("location_timestamp", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("location_accuracy", sa.Float(), nullable=True),
+        sa.Column("contact_email", sa.String(), nullable=True),
+        sa.Column("contact_phone", sa.String(), nullable=True),
+        sa.Column("age", sa.Integer(), nullable=True),
+        sa.Column("slogan", sa.String(), nullable=True),
+        sa.Column("avatar_url", sa.String(), nullable=True),
+        sa.Column("firstName", sa.String(), nullable=True),
+        sa.Column("lastName", sa.String(), nullable=True),
+        sa.Column("interests", sa.JSON(), nullable=True),
+        sa.Column("hometown", sa.String(), nullable=True),
+        sa.Column("birthdate", sa.String(), nullable=True),
+        sa.Column("gender", sa.String(), nullable=True),
+        sa.Column("sexuality", sa.String(), nullable=True),
+        sa.Column("relationship_style", sa.String(), nullable=True),
+        sa.Column("relationship_status", sa.String(), nullable=True),
+        sa.Column("social_vibes", sa.JSON(), nullable=True),
+        sa.Column("pronomen", sa.String(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("userId"),
+    )
+
+    # ── token_storage ─────────────────────────────────────────────────────────
+    op.create_table(
+        "token_storage",
+        sa.Column("userId", sa.Integer(), nullable=False),
+        sa.Column("externalAccessToken", sa.String(), nullable=False),
+        sa.Column("createdAt", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("expiresAt", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("userId"),
+    )
+
+    # ── user_events ───────────────────────────────────────────────────────────
+    op.create_table(
+        "user_events",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("userId", sa.Integer(), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("start", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("end", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("maxAttendees", sa.Integer(), nullable=True),
+        sa.Column("location_description", sa.String(), nullable=True),
+        sa.Column("location_address", sa.String(), nullable=True),
+        sa.Column("location_marker", sa.String(), nullable=True),
+        sa.Column("location_latitude", sa.Float(), nullable=True),
+        sa.Column("location_longitude", sa.Float(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_user_events_userId", "user_events", ["userId"])
+    op.create_index("ix_user_events_start", "user_events", ["start"])
+
+    # ── event_hosts ───────────────────────────────────────────────────────────
+    op.create_table(
+        "event_hosts",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("event_id", sa.Integer(), nullable=False),
+        sa.Column("userId", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(["event_id"], ["user_events.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("event_id", "userId", name="uq_event_host"),
+    )
+    op.create_index("ix_event_hosts_event_id", "event_hosts", ["event_id"])
+
+    # ── event_suggested_hosts ─────────────────────────────────────────────────
+    op.create_table(
+        "event_suggested_hosts",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("event_id", sa.Integer(), nullable=False),
+        sa.Column("userId", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(["event_id"], ["user_events.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("event_id", "userId", name="uq_event_suggested_host"),
+    )
+    op.create_index("ix_event_suggested_hosts_event_id", "event_suggested_hosts", ["event_id"])
+
+    # ── event_attendees ───────────────────────────────────────────────────────
+    op.create_table(
+        "event_attendees",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("event_id", sa.Integer(), nullable=False),
+        sa.Column("userId", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(["event_id"], ["user_events.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("event_id", "userId", name="uq_event_attendee"),
+    )
+    op.create_index("ix_event_attendees_event_id", "event_attendees", ["event_id"])
+
+    # ── event_reports ─────────────────────────────────────────────────────────
+    op.create_table(
+        "event_reports",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("event_id", sa.Integer(), nullable=False),
+        sa.Column("userId", sa.Integer(), nullable=False),
+        sa.Column("text", sa.Text(), nullable=False),
+        sa.ForeignKeyConstraint(["event_id"], ["user_events.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_event_reports_event_id", "event_reports", ["event_id"])
+
+    # ── external_event_details ────────────────────────────────────────────────
+    op.create_table(
+        "external_event_details",
+        sa.Column("eventId", sa.Integer(), nullable=False),
+        sa.Column("eventDate", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("startTime", sa.String(), nullable=False),
+        sa.Column("endTime", sa.String(), nullable=False),
+        sa.Column("titel", sa.String(), nullable=True),
+        sa.Column("description", sa.Text(), nullable=False),
+        sa.Column("speaker", sa.String(), nullable=False),
+        sa.Column("location", sa.String(), nullable=False),
+        sa.Column("locationInfo", sa.String(), nullable=True),
+        sa.Column("mapUrl", sa.String(), nullable=True),
+        sa.Column("isFree", sa.Boolean(), nullable=False),
+        sa.Column("price", sa.Integer(), nullable=False),
+        sa.Column("isLimited", sa.Boolean(), nullable=False),
+        sa.Column("stock", sa.Integer(), nullable=False),
+        sa.Column("showBooked", sa.Boolean(), nullable=False),
+        sa.Column("booked", sa.Integer(), nullable=False),
+        sa.Column("dateBookingStart", sa.String(), nullable=True),
+        sa.Column("dateBookingEnd", sa.String(), nullable=True),
+        sa.Column("imageUrl150", sa.String(), nullable=True),
+        sa.Column("imageUrl300", sa.String(), nullable=True),
+        sa.Column("eventUrl", sa.String(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("eventId"),
+    )
+
+    # ── external_event_admins ─────────────────────────────────────────────────
+    op.create_table(
+        "external_event_admins",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("eventId", sa.Integer(), nullable=False),
+        sa.Column("admin_id", sa.String(), nullable=False),
+        sa.ForeignKeyConstraint(["eventId"], ["external_event_details.eventId"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_external_event_admins_eventId", "external_event_admins", ["eventId"])
+
+    # ── external_event_categories ─────────────────────────────────────────────
+    op.create_table(
+        "external_event_categories",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("eventId", sa.Integer(), nullable=False),
+        sa.Column("code", sa.String(), nullable=False),
+        sa.Column("text", sa.String(), nullable=False),
+        sa.Column("colorText", sa.String(), nullable=False),
+        sa.Column("colorBackground", sa.String(), nullable=False),
+        sa.ForeignKeyConstraint(["eventId"], ["external_event_details.eventId"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_external_event_categories_eventId", "external_event_categories", ["eventId"])
+
+    # ── external_root ─────────────────────────────────────────────────────────
+    op.create_table(
+        "external_root",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("version", sa.Integer(), nullable=False),
+        sa.Column("loginUrl", sa.String(), nullable=False),
+        sa.Column("restUrl", sa.String(), nullable=False),
+        sa.Column("siteUrl", sa.String(), nullable=False),
+        sa.Column("header1", sa.String(), nullable=False),
+        sa.Column("header2", sa.String(), nullable=False),
+        sa.Column("city", sa.String(), nullable=False),
+        sa.Column("streetAddress", sa.String(), nullable=False),
+        sa.Column("mapUrl", sa.String(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint("id = 1", name="ck_external_root_singleton"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    # ── external_root_dates ───────────────────────────────────────────────────
+    op.create_table(
+        "external_root_dates",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("root_id", sa.Integer(), nullable=False),
+        sa.Column("date_value", sa.String(), nullable=False),
+        sa.ForeignKeyConstraint(["root_id"], ["external_root.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    # ── external_event_bookings ───────────────────────────────────────────────
+    op.create_table(
+        "external_event_bookings",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("userId", sa.Integer(), nullable=False),
+        sa.Column("eventId", sa.Integer(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("userId", "eventId", name="uq_external_event_booking"),
+    )
+    op.create_index("ix_external_event_bookings_userId", "external_event_bookings", ["userId"])
+    op.create_index("ix_external_event_bookings_eventId", "external_event_bookings", ["eventId"])
+
+    # ── feedback_votes ────────────────────────────────────────────────────────
+    op.create_table(
+        "feedback_votes",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("issue_number", sa.Integer(), nullable=False),
+        sa.Column("user_hash", sa.String(), nullable=False),
+        sa.Column("value", sa.Integer(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("issue_number", "user_hash", name="uq_feedback_vote"),
+    )
+    op.create_index("ix_feedback_votes_issue_number", "feedback_votes", ["issue_number"])
+
+    # ── feedback_user_index ───────────────────────────────────────────────────
+    op.create_table(
+        "feedback_user_index",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("user_hash", sa.String(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=True),
+        sa.Column("member_number", sa.String(), nullable=True),
+        sa.Column("is_member", sa.Boolean(), nullable=False),
+        sa.Column("first_seen", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("last_seen", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("user_hash"),
+    )
+    op.create_index("ix_feedback_user_index_user_hash", "feedback_user_index", ["user_hash"])
+    op.create_index("ix_feedback_user_index_user_id", "feedback_user_index", ["user_id"])
+
+
+def downgrade() -> None:
+    op.drop_table("feedback_user_index")
+    op.drop_table("feedback_votes")
+    op.drop_table("external_event_bookings")
+    op.drop_table("external_root_dates")
+    op.drop_table("external_root")
+    op.drop_table("external_event_categories")
+    op.drop_table("external_event_admins")
+    op.drop_table("external_event_details")
+    op.drop_table("event_reports")
+    op.drop_table("event_attendees")
+    op.drop_table("event_suggested_hosts")
+    op.drop_table("event_hosts")
+    op.drop_table("user_events")
+    op.drop_table("token_storage")
+    op.drop_table("users")

--- a/backend/alembic/versions/001_initial_schema.py
+++ b/backend/alembic/versions/001_initial_schema.py
@@ -15,6 +15,7 @@ from typing import Sequence, Union
 
 import sqlalchemy as sa
 from alembic import op
+from sqlalchemy.dialects import postgresql
 
 revision: str = "001"
 down_revision: Union[str, None] = None
@@ -56,14 +57,14 @@ def upgrade() -> None:
         sa.Column("avatar_url", sa.String(), nullable=True),
         sa.Column("firstName", sa.String(), nullable=True),
         sa.Column("lastName", sa.String(), nullable=True),
-        sa.Column("interests", sa.JSON(), nullable=True),
+        sa.Column("interests", postgresql.JSONB(), nullable=True),
         sa.Column("hometown", sa.String(), nullable=True),
         sa.Column("birthdate", sa.String(), nullable=True),
         sa.Column("gender", sa.String(), nullable=True),
         sa.Column("sexuality", sa.String(), nullable=True),
         sa.Column("relationship_style", sa.String(), nullable=True),
         sa.Column("relationship_status", sa.String(), nullable=True),
-        sa.Column("social_vibes", sa.JSON(), nullable=True),
+        sa.Column("social_vibes", postgresql.JSONB(), nullable=True),
         sa.Column("pronomen", sa.String(), nullable=True),
         sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
         sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),

--- a/backend/migrations/mongo_to_postgres.py
+++ b/backend/migrations/mongo_to_postgres.py
@@ -22,6 +22,7 @@ FeedbackVoteTable and FeedbackUserIndexTable have no MongoDB counterpart
 (they are Postgres-only) and are skipped.
 """
 
+import json
 import logging
 import os
 import sys
@@ -175,8 +176,8 @@ def migrate_users(session):
                 :location_latitude, :location_longitude, :location_timestamp, :location_accuracy,
                 :contact_email, :contact_phone,
                 :age, :slogan, :avatar_url, :firstName, :lastName,
-                :interests::jsonb, :hometown, :birthdate, :gender, :sexuality,
-                :relationship_style, :relationship_status, :social_vibes::jsonb, :pronomen,
+                :interests, :hometown, :birthdate, :gender, :sexuality,
+                :relationship_style, :relationship_status, :social_vibes, :pronomen,
                 :created_at, :updated_at
             )
             ON CONFLICT ("userId") DO UPDATE SET
@@ -219,8 +220,8 @@ def migrate_users(session):
                 social_vibes                        = EXCLUDED.social_vibes,
                 pronomen                            = EXCLUDED.pronomen,
                 updated_at                          = EXCLUDED.updated_at
-        """), {**row, "interests": __import__("json").dumps(row["interests"]),
-                      "social_vibes": __import__("json").dumps(row["social_vibes"])})
+        """), {**row, "interests": json.dumps(row["interests"]),
+                      "social_vibes": json.dumps(row["social_vibes"])})
 
         inserted += 1
 
@@ -263,15 +264,34 @@ def migrate_token_storage(session):
 
 # ── User events ───────────────────────────────────────────────────────────────
 
+def _ensure_migration_tracking(session):
+    """Create a migration-tracking table if it doesn't already exist.
+
+    _mongo_migration_log maps (collection, mongo_id) → postgres id so that
+    re-runs of the migration can detect already-migrated documents without
+    relying on non-existent unique constraints on the target tables.
+    """
+    session.execute(text("""
+        CREATE TABLE IF NOT EXISTS _mongo_migration_log (
+            collection  VARCHAR NOT NULL,
+            mongo_id    VARCHAR NOT NULL,
+            pg_id       INTEGER NOT NULL,
+            PRIMARY KEY (collection, mongo_id)
+        )
+    """))
+    session.commit()
+
+
 def migrate_user_events(session):
-    import json
+    _ensure_migration_tracking(session)
     coll = mongo_db["userevent"]
     total = coll.count_documents({})
     log.info("userevent: %d documents in Mongo", total)
 
-    inserted = 0
+    processed = skipped = 0
     for doc in coll.find():
         mongo_id = doc.get("_id")  # ObjectId
+        mongo_id_str = str(mongo_id)
         uid = doc.get("userId")
         if uid is None:
             log.warning("userevent missing userId, skipping %s", mongo_id)
@@ -279,58 +299,57 @@ def migrate_user_events(session):
 
         loc = doc.get("location") or {}
 
-        # Upsert the parent event row.
-        # We use the Mongo ObjectId hex as a stable external key to detect
-        # re-runs. Postgres auto-generates the integer id; we look it up after.
-        external_id = str(mongo_id)
-        result = session.execute(text("""
-            INSERT INTO user_events (
-                "userId", name, start, "end", description, "maxAttendees",
-                location_description, location_address, location_marker,
-                location_latitude, location_longitude,
-                created_at, updated_at
-            )
-            VALUES (
-                :userId, :name, :start, :end, :description, :maxAttendees,
-                :loc_desc, :loc_addr, :loc_marker,
-                :loc_lat, :loc_lon,
-                :created_at, :updated_at
-            )
-            ON CONFLICT DO NOTHING
-            RETURNING id
-        """), {
-            "userId": uid,
-            "name": _str(doc.get("name"), "Unnamed"),
-            "start": _tz(doc.get("start")),
-            "end": _tz(doc.get("end")),
-            "description": doc.get("description"),
-            "maxAttendees": doc.get("maxAttendees"),
-            "loc_desc": loc.get("description"),
-            "loc_addr": loc.get("address"),
-            "loc_marker": loc.get("marker"),
-            "loc_lat": loc.get("latitude"),
-            "loc_lon": loc.get("longitude"),
-            "created_at": _tz(doc.get("createdAt")) or datetime.now(timezone.utc),
-            "updated_at": _tz(doc.get("updatedAt")) or datetime.now(timezone.utc),
-        })
+        # Check if this Mongo document was already migrated (idempotency key).
+        existing_map = session.execute(text("""
+            SELECT pg_id FROM _mongo_migration_log
+            WHERE collection = 'userevent' AND mongo_id = :mid
+        """), {"mid": mongo_id_str}).fetchone()
 
-        row = result.fetchone()
-        if row is None:
-            # Row already existed (ON CONFLICT DO NOTHING): look it up by natural key
-            existing = session.execute(text("""
-                SELECT id FROM user_events
-                WHERE "userId" = :uid AND name = :name AND start = :start
-                LIMIT 1
-            """), {"uid": uid, "name": _str(doc.get("name"), "Unnamed"),
-                   "start": _tz(doc.get("start"))}).fetchone()
-            if existing is None:
-                log.warning("Could not find pg id for userevent %s, skipping children", mongo_id)
-                continue
-            event_pg_id = existing[0]
+        if existing_map is not None:
+            event_pg_id = existing_map[0]
+            skipped += 1
         else:
-            event_pg_id = row[0]
+            result = session.execute(text("""
+                INSERT INTO user_events (
+                    "userId", name, start, "end", description, "maxAttendees",
+                    location_description, location_address, location_marker,
+                    location_latitude, location_longitude,
+                    created_at, updated_at
+                )
+                VALUES (
+                    :userId, :name, :start, :end, :description, :maxAttendees,
+                    :loc_desc, :loc_addr, :loc_marker,
+                    :loc_lat, :loc_lon,
+                    :created_at, :updated_at
+                )
+                RETURNING id
+            """), {
+                "userId": uid,
+                "name": _str(doc.get("name"), "Unnamed"),
+                "start": _tz(doc.get("start")),
+                "end": _tz(doc.get("end")),
+                "description": doc.get("description"),
+                "maxAttendees": doc.get("maxAttendees"),
+                "loc_desc": loc.get("description"),
+                "loc_addr": loc.get("address"),
+                "loc_marker": loc.get("marker"),
+                "loc_lat": loc.get("latitude"),
+                "loc_lon": loc.get("longitude"),
+                "created_at": _tz(doc.get("createdAt")) or datetime.now(timezone.utc),
+                "updated_at": _tz(doc.get("updatedAt")) or datetime.now(timezone.utc),
+            })
+            event_pg_id = result.fetchone()[0]
 
-        # Child rows — idempotent via ON CONFLICT DO NOTHING
+            # Record the mapping so re-runs skip this document.
+            session.execute(text("""
+                INSERT INTO _mongo_migration_log (collection, mongo_id, pg_id)
+                VALUES ('userevent', :mid, :pid)
+                ON CONFLICT DO NOTHING
+            """), {"mid": mongo_id_str, "pid": event_pg_id})
+
+            processed += 1
+
+        # Child rows — idempotent via named unique constraints.
         for h in doc.get("hosts") or []:
             huid = h.get("userId")
             if huid is not None:
@@ -368,11 +387,9 @@ def migrate_user_events(session):
                     ON CONFLICT DO NOTHING
                 """), {"eid": event_pg_id, "uid": ruid, "text": rtext})
 
-        inserted += 1
-
     session.commit()
-    log.info("userevent: %d processed", inserted)
-    return total, inserted
+    log.info("userevent: %d inserted, %d already migrated (skipped)", processed, skipped)
+    return total, processed
 
 
 # ── External event details ────────────────────────────────────────────────────
@@ -493,6 +510,9 @@ def migrate_external_root(session):
         log.info("externalroot: nothing to migrate")
         return 0, 0
 
+    if total > 1:
+        log.warning("externalroot: %d documents found in Mongo (expected 1); using first", total)
+
     doc = coll.find_one()
     now = datetime.now(timezone.utc)
 
@@ -582,7 +602,7 @@ def validate(session):
     for pg_table, mongo_coll, _note in checks:
         mongo_count = mongo_db[mongo_coll].count_documents({})
         pg_count = session.execute(text(f'SELECT COUNT(*) FROM "{pg_table}"')).scalar()
-        status = "OK" if pg_count >= mongo_count else "MISMATCH"
+        status = "OK" if pg_count == mongo_count else "MISMATCH"
         if status != "OK":
             all_ok = False
         log.info(

--- a/backend/migrations/mongo_to_postgres.py
+++ b/backend/migrations/mongo_to_postgres.py
@@ -5,8 +5,7 @@ Usage:
     MONGO_URL=mongodb://mongo:27017  DATABASE_URL=postgresql://swag:swag@postgres:5432/swag \
         python -m migrations.mongo_to_postgres
 
-Idempotent: safe to run multiple times — uses INSERT … ON CONFLICT DO NOTHING (or DO UPDATE)
-so rows already present in Postgres are not duplicated or overwritten.
+Idempotent: safe to run multiple times.
 
 Migrates:
     user          → users
@@ -19,7 +18,15 @@ Migrates:
     externaleventbooking → external_event_bookings
 
 FeedbackVoteTable and FeedbackUserIndexTable have no MongoDB counterpart
-(they are Postgres-only) and are skipped.
+(Postgres-only) and are skipped.
+
+Design notes:
+  - Every migrate_* function accepts an optional mongo_source parameter.
+    Pass a FakeMongo in tests; omit it in production (lazy real connection).
+  - ON CONFLICT clauses use explicit column lists, not named constraints,
+    so the SQL runs identically on SQLite (tests) and PostgreSQL (production).
+  - user_events idempotency uses _mongo_migration_log (a tracking table
+    keyed on Mongo ObjectId) because user_events has no natural unique key.
 """
 
 import json
@@ -31,7 +38,6 @@ from datetime import datetime, timezone
 # Allow running as: python -m migrations.mongo_to_postgres from backend/
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from pymongo import MongoClient
 from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker
 
@@ -39,16 +45,23 @@ logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
 log = logging.getLogger(__name__)
 
 
-# ── Connection setup ──────────────────────────────────────────────────────────
+# ── Connection setup (lazy — does NOT connect on import) ──────────────────────
 
 MONGO_URL = os.environ.get("MONGO_URL", "mongodb://mongo:27017")
 DATABASE_URL = os.environ.get("DATABASE_URL", "postgresql://swag:swag@postgres:5432/swag")
 
-mongo_client = MongoClient(MONGO_URL)
-mongo_db = mongo_client["swag"]
+_mongo_client = None
+_mongo_db = None
 
-pg_engine = create_engine(DATABASE_URL, echo=False)
-Session = sessionmaker(bind=pg_engine)
+
+def _get_live_mongo():
+    """Connect to Mongo on first call. Never called in tests."""
+    global _mongo_client, _mongo_db
+    if _mongo_db is None:
+        from pymongo import MongoClient
+        _mongo_client = MongoClient(MONGO_URL)
+        _mongo_db = _mongo_client["swag"]
+    return _mongo_db
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
@@ -84,14 +97,35 @@ def _bool(v, default=False):
     return bool(v)
 
 
+def _privacy(v, default="NO_ONE"):
+    """Coerce a privacy field to a valid PrivacySetting string.
+
+    Old Mongo documents stored show_email / show_phone as booleans before
+    the PrivacySetting enum was introduced:
+        True  → "MEMBERS_ONLY"
+        False → "NO_ONE"
+    Newer documents already store the string enum value.
+    Using _str() here would silently produce "True"/"False" — invalid values
+    that break PrivacySetting parsing in the application layer.
+    """
+    if v is None:
+        return default
+    if v is True:
+        return "MEMBERS_ONLY"
+    if v is False:
+        return "NO_ONE"
+    return str(v)
+
+
 # ── Users ─────────────────────────────────────────────────────────────────────
 
-def migrate_users(session):
-    coll = mongo_db["user"]
+def migrate_users(session, mongo_source=None):
+    source = mongo_source if mongo_source is not None else _get_live_mongo()
+    coll = source["user"]
     total = coll.count_documents({})
     log.info("users: %d documents in Mongo", total)
 
-    inserted = skipped = 0
+    upserted = 0
     for doc in coll.find():
         uid = doc.get("userId")
         if uid is None:
@@ -101,27 +135,27 @@ def migrate_users(session):
         s = doc.get("settings") or {}
         loc = doc.get("location") or {}
         ci = doc.get("contact_info") or {}
-
         interests = doc.get("interests") or []
         social_vibes = doc.get("social_vibes") or []
 
         row = {
             "userId": uid,
             "isMember": _bool(doc.get("isMember")),
-            "show_location": _str(s.get("show_location"), "NO_ONE"),
-            "show_profile": _str(s.get("show_profile"), "MEMBERS_MUTUAL"),
-            "show_email": _str(s.get("show_email"), "NO_ONE"),
-            "show_phone": _str(s.get("show_phone"), "NO_ONE"),
-            "show_interests": _str(s.get("show_interests"), "MEMBERS_MUTUAL"),
-            "show_hometown": _str(s.get("show_hometown"), "MEMBERS_MUTUAL"),
-            "show_birthdate": _str(s.get("show_birthdate"), "MEMBERS_MUTUAL"),
-            "show_gender": _str(s.get("show_gender"), "NO_ONE"),
-            "show_sexuality": _str(s.get("show_sexuality"), "NO_ONE"),
-            "show_relationship_style": _str(s.get("show_relationship_style"), "NO_ONE"),
-            "show_relationship_status": _str(s.get("show_relationship_status"), "NO_ONE"),
-            "show_social_vibes": _str(s.get("show_social_vibes"), "MEMBERS_MUTUAL"),
-            "show_pronomen": _str(s.get("show_pronomen"), "NO_ONE"),
-            "show_attendance": _str(s.get("show_attendance"), "MEMBERS_MUTUAL"),
+            "show_location": _privacy(s.get("show_location"), "NO_ONE"),
+            "show_profile": _privacy(s.get("show_profile"), "MEMBERS_MUTUAL"),
+            # show_email / show_phone were historically stored as booleans.
+            "show_email": _privacy(s.get("show_email"), "NO_ONE"),
+            "show_phone": _privacy(s.get("show_phone"), "NO_ONE"),
+            "show_interests": _privacy(s.get("show_interests"), "MEMBERS_MUTUAL"),
+            "show_hometown": _privacy(s.get("show_hometown"), "MEMBERS_MUTUAL"),
+            "show_birthdate": _privacy(s.get("show_birthdate"), "MEMBERS_MUTUAL"),
+            "show_gender": _privacy(s.get("show_gender"), "NO_ONE"),
+            "show_sexuality": _privacy(s.get("show_sexuality"), "NO_ONE"),
+            "show_relationship_style": _privacy(s.get("show_relationship_style"), "NO_ONE"),
+            "show_relationship_status": _privacy(s.get("show_relationship_status"), "NO_ONE"),
+            "show_social_vibes": _privacy(s.get("show_social_vibes"), "MEMBERS_MUTUAL"),
+            "show_pronomen": _privacy(s.get("show_pronomen"), "NO_ONE"),
+            "show_attendance": _privacy(s.get("show_attendance"), "MEMBERS_MUTUAL"),
             "location_update_interval_seconds": _int(s.get("location_update_interval_seconds"), 60),
             "events_refresh_interval_seconds": _int(s.get("events_refresh_interval_seconds"), 60),
             "background_location_updates": _bool(s.get("background_location_updates")),
@@ -149,7 +183,7 @@ def migrate_users(session):
             "updated_at": _tz(doc.get("updated_at")) or datetime.now(timezone.utc),
         }
 
-        result = session.execute(text("""
+        session.execute(text("""
             INSERT INTO users (
                 "userId", "isMember",
                 show_location, show_profile, show_email, show_phone,
@@ -222,25 +256,26 @@ def migrate_users(session):
                 updated_at                          = EXCLUDED.updated_at
         """), {**row, "interests": json.dumps(row["interests"]),
                       "social_vibes": json.dumps(row["social_vibes"])})
-
-        inserted += 1
+        upserted += 1
 
     session.commit()
-    log.info("users: %d upserted", inserted)
-    return total, inserted
+    log.info("users: %d upserted", upserted)
+    return total, upserted
 
 
 # ── Token storage ─────────────────────────────────────────────────────────────
 
-def migrate_token_storage(session):
-    coll = mongo_db["tokenstorage"]
+def migrate_token_storage(session, mongo_source=None):
+    source = mongo_source if mongo_source is not None else _get_live_mongo()
+    coll = source["tokenstorage"]
     total = coll.count_documents({})
     log.info("tokenstorage: %d documents in Mongo", total)
 
-    inserted = 0
+    upserted = 0
     for doc in coll.find():
         uid = doc.get("userId")
         if uid is None:
+            log.warning("tokenstorage doc missing userId, skipping")
             continue
         session.execute(text("""
             INSERT INTO token_storage ("userId", "externalAccessToken", "createdAt", "expiresAt")
@@ -255,22 +290,17 @@ def migrate_token_storage(session):
             "createdAt": _tz(doc.get("createdAt")) or datetime.now(timezone.utc),
             "expiresAt": _tz(doc.get("expiresAt")) or datetime.now(timezone.utc),
         })
-        inserted += 1
+        upserted += 1
 
     session.commit()
-    log.info("tokenstorage: %d upserted", inserted)
-    return total, inserted
+    log.info("tokenstorage: %d upserted", upserted)
+    return total, upserted
 
 
 # ── User events ───────────────────────────────────────────────────────────────
 
 def _ensure_migration_tracking(session):
-    """Create a migration-tracking table if it doesn't already exist.
-
-    _mongo_migration_log maps (collection, mongo_id) → postgres id so that
-    re-runs of the migration can detect already-migrated documents without
-    relying on non-existent unique constraints on the target tables.
-    """
+    """Create the idempotency-tracking table if it doesn't already exist."""
     session.execute(text("""
         CREATE TABLE IF NOT EXISTS _mongo_migration_log (
             collection  VARCHAR NOT NULL,
@@ -282,15 +312,26 @@ def _ensure_migration_tracking(session):
     session.commit()
 
 
-def migrate_user_events(session):
+def migrate_user_events(session, mongo_source=None):
+    """Migrate user events and all child rows.
+
+    Idempotency: user_events has no natural unique key, so we track each
+    migrated Mongo document by ObjectId in _mongo_migration_log. Re-runs
+    skip already-logged documents entirely — child rows are therefore also
+    never re-inserted.
+
+    ON CONFLICT clauses use explicit column lists (not named constraints)
+    so the SQL runs on both SQLite (tests) and PostgreSQL (production).
+    """
     _ensure_migration_tracking(session)
-    coll = mongo_db["userevent"]
+    source = mongo_source if mongo_source is not None else _get_live_mongo()
+    coll = source["userevent"]
     total = coll.count_documents({})
     log.info("userevent: %d documents in Mongo", total)
 
-    processed = skipped = 0
+    inserted = skipped = 0
     for doc in coll.find():
-        mongo_id = doc.get("_id")  # ObjectId
+        mongo_id = doc.get("_id")
         mongo_id_str = str(mongo_id)
         uid = doc.get("userId")
         if uid is None:
@@ -299,17 +340,16 @@ def migrate_user_events(session):
 
         loc = doc.get("location") or {}
 
-        # Check if this Mongo document was already migrated (idempotency key).
-        existing_map = session.execute(text("""
+        existing = session.execute(text("""
             SELECT pg_id FROM _mongo_migration_log
             WHERE collection = 'userevent' AND mongo_id = :mid
         """), {"mid": mongo_id_str}).fetchone()
 
-        if existing_map is not None:
-            event_pg_id = existing_map[0]
+        if existing is not None:
+            event_pg_id = existing[0]
             skipped += 1
         else:
-            result = session.execute(text("""
+            row = session.execute(text("""
                 INSERT INTO user_events (
                     "userId", name, start, "end", description, "maxAttendees",
                     location_description, location_address, location_marker,
@@ -318,8 +358,7 @@ def migrate_user_events(session):
                 )
                 VALUES (
                     :userId, :name, :start, :end, :description, :maxAttendees,
-                    :loc_desc, :loc_addr, :loc_marker,
-                    :loc_lat, :loc_lon,
+                    :loc_desc, :loc_addr, :loc_marker, :loc_lat, :loc_lon,
                     :created_at, :updated_at
                 )
                 RETURNING id
@@ -337,26 +376,24 @@ def migrate_user_events(session):
                 "loc_lon": loc.get("longitude"),
                 "created_at": _tz(doc.get("createdAt")) or datetime.now(timezone.utc),
                 "updated_at": _tz(doc.get("updatedAt")) or datetime.now(timezone.utc),
-            })
-            event_pg_id = result.fetchone()[0]
+            }).fetchone()
+            event_pg_id = row[0]
 
-            # Record the mapping so re-runs skip this document.
             session.execute(text("""
                 INSERT INTO _mongo_migration_log (collection, mongo_id, pg_id)
                 VALUES ('userevent', :mid, :pid)
                 ON CONFLICT DO NOTHING
             """), {"mid": mongo_id_str, "pid": event_pg_id})
+            inserted += 1
 
-            processed += 1
-
-        # Child rows — idempotent via named unique constraints.
+        # Child rows. ON CONFLICT uses explicit columns (works on SQLite + Postgres).
         for h in doc.get("hosts") or []:
             huid = h.get("userId")
             if huid is not None:
                 session.execute(text("""
                     INSERT INTO event_hosts (event_id, "userId")
                     VALUES (:eid, :uid)
-                    ON CONFLICT ON CONSTRAINT uq_event_host DO NOTHING
+                    ON CONFLICT (event_id, "userId") DO NOTHING
                 """), {"eid": event_pg_id, "uid": huid})
 
         for h in doc.get("suggested_hosts") or []:
@@ -365,7 +402,7 @@ def migrate_user_events(session):
                 session.execute(text("""
                     INSERT INTO event_suggested_hosts (event_id, "userId")
                     VALUES (:eid, :uid)
-                    ON CONFLICT ON CONSTRAINT uq_event_suggested_host DO NOTHING
+                    ON CONFLICT (event_id, "userId") DO NOTHING
                 """), {"eid": event_pg_id, "uid": huid})
 
         for a in doc.get("attendees") or []:
@@ -374,9 +411,10 @@ def migrate_user_events(session):
                 session.execute(text("""
                     INSERT INTO event_attendees (event_id, "userId")
                     VALUES (:eid, :uid)
-                    ON CONFLICT ON CONSTRAINT uq_event_attendee DO NOTHING
+                    ON CONFLICT (event_id, "userId") DO NOTHING
                 """), {"eid": event_pg_id, "uid": auid})
 
+        # Reports have no unique constraint; tracking table prevents re-insertion.
         for r in doc.get("reports") or []:
             ruid = r.get("userId")
             rtext = r.get("text", "")
@@ -384,22 +422,22 @@ def migrate_user_events(session):
                 session.execute(text("""
                     INSERT INTO event_reports (event_id, "userId", text)
                     VALUES (:eid, :uid, :text)
-                    ON CONFLICT DO NOTHING
                 """), {"eid": event_pg_id, "uid": ruid, "text": rtext})
 
     session.commit()
-    log.info("userevent: %d inserted, %d already migrated (skipped)", processed, skipped)
-    return total, processed
+    log.info("userevent: %d inserted, %d skipped (already migrated)", inserted, skipped)
+    return total, inserted
 
 
 # ── External event details ────────────────────────────────────────────────────
 
-def migrate_external_events(session):
-    coll = mongo_db["externaleventdetails"]
+def migrate_external_events(session, mongo_source=None):
+    source = mongo_source if mongo_source is not None else _get_live_mongo()
+    coll = source["externaleventdetails"]
     total = coll.count_documents({})
     log.info("externaleventdetails: %d documents in Mongo", total)
 
-    inserted = 0
+    upserted = 0
     for doc in coll.find():
         eid = doc.get("eventId")
         if eid is None:
@@ -470,19 +508,19 @@ def migrate_external_events(session):
             "updated_at": _tz(doc.get("updated_at")) or datetime.now(timezone.utc),
         })
 
-        # Admins — delete and re-insert for idempotency
+        # Delete-then-reinsert: correct for idempotency since these child tables
+        # have no meaningful unique key beyond (eventId, value).
         session.execute(text('DELETE FROM external_event_admins WHERE "eventId" = :eid'), {"eid": eid})
         for admin_id in doc.get("admins") or []:
             session.execute(text("""
-                INSERT INTO external_event_admins ("eventId", admin_id)
-                VALUES (:eid, :aid)
+                INSERT INTO external_event_admins ("eventId", admin_id) VALUES (:eid, :aid)
             """), {"eid": eid, "aid": str(admin_id)})
 
-        # Categories — delete and re-insert for idempotency
         session.execute(text('DELETE FROM external_event_categories WHERE "eventId" = :eid'), {"eid": eid})
         for cat in doc.get("categories") or []:
             session.execute(text("""
-                INSERT INTO external_event_categories ("eventId", code, text, "colorText", "colorBackground")
+                INSERT INTO external_event_categories
+                    ("eventId", code, text, "colorText", "colorBackground")
                 VALUES (:eid, :code, :text, :ct, :cb)
             """), {
                 "eid": eid,
@@ -491,18 +529,18 @@ def migrate_external_events(session):
                 "ct": _str(cat.get("colorText")),
                 "cb": _str(cat.get("colorBackground")),
             })
-
-        inserted += 1
+        upserted += 1
 
     session.commit()
-    log.info("externaleventdetails: %d upserted", inserted)
-    return total, inserted
+    log.info("externaleventdetails: %d upserted", upserted)
+    return total, upserted
 
 
 # ── External root ─────────────────────────────────────────────────────────────
 
-def migrate_external_root(session):
-    coll = mongo_db["externalroot"]
+def migrate_external_root(session, mongo_source=None):
+    source = mongo_source if mongo_source is not None else _get_live_mongo()
+    coll = source["externalroot"]
     total = coll.count_documents({})
     log.info("externalroot: %d documents in Mongo", total)
 
@@ -511,29 +549,27 @@ def migrate_external_root(session):
         return 0, 0
 
     if total > 1:
-        log.warning("externalroot: %d documents found in Mongo (expected 1); using first", total)
+        log.warning("externalroot: %d documents in Mongo (expected 1); using first", total)
 
     doc = coll.find_one()
     now = datetime.now(timezone.utc)
 
     session.execute(text("""
         INSERT INTO external_root (id, version, "loginUrl", "restUrl", "siteUrl",
-            header1, header2, city, "streetAddress", "mapUrl",
-            created_at, updated_at)
+            header1, header2, city, "streetAddress", "mapUrl", created_at, updated_at)
         VALUES (1, :version, :loginUrl, :restUrl, :siteUrl,
-            :header1, :header2, :city, :streetAddress, :mapUrl,
-            :created_at, :updated_at)
+            :header1, :header2, :city, :streetAddress, :mapUrl, :created_at, :updated_at)
         ON CONFLICT (id) DO UPDATE SET
-            version        = EXCLUDED.version,
-            "loginUrl"     = EXCLUDED."loginUrl",
-            "restUrl"      = EXCLUDED."restUrl",
-            "siteUrl"      = EXCLUDED."siteUrl",
-            header1        = EXCLUDED.header1,
-            header2        = EXCLUDED.header2,
-            city           = EXCLUDED.city,
-            "streetAddress"= EXCLUDED."streetAddress",
-            "mapUrl"       = EXCLUDED."mapUrl",
-            updated_at     = EXCLUDED.updated_at
+            version         = EXCLUDED.version,
+            "loginUrl"      = EXCLUDED."loginUrl",
+            "restUrl"       = EXCLUDED."restUrl",
+            "siteUrl"       = EXCLUDED."siteUrl",
+            header1         = EXCLUDED.header1,
+            header2         = EXCLUDED.header2,
+            city            = EXCLUDED.city,
+            "streetAddress" = EXCLUDED."streetAddress",
+            "mapUrl"        = EXCLUDED."mapUrl",
+            updated_at      = EXCLUDED.updated_at
     """), {
         "version": _int(doc.get("version")),
         "loginUrl": _str(doc.get("loginUrl")),
@@ -548,13 +584,11 @@ def migrate_external_root(session):
         "updated_at": now,
     })
 
-    # Dates — replace for idempotency
     session.execute(text("DELETE FROM external_root_dates WHERE root_id = 1"))
     for date_str in doc.get("dates") or []:
         session.execute(text("""
-            INSERT INTO external_root_dates (root_id, date_value)
-            VALUES (1, :date_value)
-        """), {"date_value": str(date_str)})
+            INSERT INTO external_root_dates (root_id, date_value) VALUES (1, :dv)
+        """), {"dv": str(date_str)})
 
     session.commit()
     log.info("externalroot: 1 upserted")
@@ -563,12 +597,13 @@ def migrate_external_root(session):
 
 # ── External event bookings ───────────────────────────────────────────────────
 
-def migrate_external_event_bookings(session):
-    coll = mongo_db["externaleventbooking"]
+def migrate_external_event_bookings(session, mongo_source=None):
+    source = mongo_source if mongo_source is not None else _get_live_mongo()
+    coll = source["externaleventbooking"]
     total = coll.count_documents({})
     log.info("externaleventbooking: %d documents in Mongo", total)
 
-    inserted = 0
+    upserted = 0
     for doc in coll.find():
         uid = doc.get("userId")
         eid = doc.get("eventId")
@@ -577,38 +612,41 @@ def migrate_external_event_bookings(session):
         session.execute(text("""
             INSERT INTO external_event_bookings ("userId", "eventId")
             VALUES (:uid, :eid)
-            ON CONFLICT ON CONSTRAINT uq_external_event_booking DO NOTHING
+            ON CONFLICT ("userId", "eventId") DO NOTHING
         """), {"uid": uid, "eid": eid})
-        inserted += 1
+        upserted += 1
 
     session.commit()
-    log.info("externaleventbooking: %d upserted", inserted)
-    return total, inserted
+    log.info("externaleventbooking: %d upserted", upserted)
+    return total, upserted
 
 
 # ── Validation ────────────────────────────────────────────────────────────────
 
-def validate(session):
-    """Compare Mongo document counts against Postgres row counts."""
+def validate(session, mongo_source=None):
+    """Compare Mongo document counts against Postgres row counts.
+
+    Uses == not >= so that double-insertion bugs (Postgres has MORE rows than
+    Mongo) are detected, not silently accepted.
+    """
+    source = mongo_source if mongo_source is not None else _get_live_mongo()
     checks = [
-        ("users",                   "user",                    None),
-        ("token_storage",           "tokenstorage",            None),
-        ("user_events",             "userevent",               None),
-        ("external_event_details",  "externaleventdetails",    None),
-        ("external_event_bookings", "externaleventbooking",    None),
+        ("users",                   "user"),
+        ("token_storage",           "tokenstorage"),
+        ("user_events",             "userevent"),
+        ("external_event_details",  "externaleventdetails"),
+        ("external_event_bookings", "externaleventbooking"),
     ]
 
     all_ok = True
-    for pg_table, mongo_coll, _note in checks:
-        mongo_count = mongo_db[mongo_coll].count_documents({})
+    for pg_table, mongo_coll in checks:
+        mongo_count = source[mongo_coll].count_documents({})
         pg_count = session.execute(text(f'SELECT COUNT(*) FROM "{pg_table}"')).scalar()
         status = "OK" if pg_count == mongo_count else "MISMATCH"
         if status != "OK":
             all_ok = False
-        log.info(
-            "VALIDATE %-30s  Mongo=%4d  Postgres=%4d  %s",
-            pg_table, mongo_count, pg_count, status,
-        )
+        log.info("VALIDATE %-30s  Mongo=%4d  Postgres=%4d  %s",
+                 pg_table, mongo_count, pg_count, status)
 
     return all_ok
 
@@ -618,7 +656,12 @@ def validate(session):
 def main():
     log.info("Starting Mongo → Postgres migration")
     log.info("Mongo:    %s", MONGO_URL)
-    log.info("Postgres: %s", DATABASE_URL.split("@")[-1])  # hide credentials
+    import urllib.parse
+    parsed = urllib.parse.urlparse(DATABASE_URL)
+    log.info("Postgres: %s@%s%s", parsed.username, parsed.hostname, parsed.path)
+
+    pg_engine = create_engine(DATABASE_URL, echo=False)
+    Session = sessionmaker(bind=pg_engine)
 
     with Session() as session:
         migrate_users(session)

--- a/backend/migrations/mongo_to_postgres.py
+++ b/backend/migrations/mongo_to_postgres.py
@@ -1,0 +1,622 @@
+"""
+Mongo → Postgres one-time data migration script.
+
+Usage:
+    MONGO_URL=mongodb://mongo:27017  DATABASE_URL=postgresql://swag:swag@postgres:5432/swag \
+        python -m migrations.mongo_to_postgres
+
+Idempotent: safe to run multiple times — uses INSERT … ON CONFLICT DO NOTHING (or DO UPDATE)
+so rows already present in Postgres are not duplicated or overwritten.
+
+Migrates:
+    user          → users
+    tokenstorage  → token_storage
+    userevent     → user_events + event_hosts + event_suggested_hosts +
+                    event_attendees + event_reports
+    externaleventdetails → external_event_details + external_event_admins +
+                           external_event_categories
+    externalroot  → external_root + external_root_dates
+    externaleventbooking → external_event_bookings
+
+FeedbackVoteTable and FeedbackUserIndexTable have no MongoDB counterpart
+(they are Postgres-only) and are skipped.
+"""
+
+import logging
+import os
+import sys
+from datetime import datetime, timezone
+
+# Allow running as: python -m migrations.mongo_to_postgres from backend/
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from pymongo import MongoClient
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+log = logging.getLogger(__name__)
+
+
+# ── Connection setup ──────────────────────────────────────────────────────────
+
+MONGO_URL = os.environ.get("MONGO_URL", "mongodb://mongo:27017")
+DATABASE_URL = os.environ.get("DATABASE_URL", "postgresql://swag:swag@postgres:5432/swag")
+
+mongo_client = MongoClient(MONGO_URL)
+mongo_db = mongo_client["swag"]
+
+pg_engine = create_engine(DATABASE_URL, echo=False)
+Session = sessionmaker(bind=pg_engine)
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _tz(dt):
+    """Ensure a datetime is timezone-aware (UTC)."""
+    if dt is None:
+        return None
+    if isinstance(dt, datetime):
+        return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def _str(v, default=""):
+    """Coerce to str, falling back to default."""
+    if v is None:
+        return default
+    return str(v)
+
+
+def _int(v, default=0):
+    if v is None:
+        return default
+    try:
+        return int(v)
+    except (TypeError, ValueError):
+        return default
+
+
+def _bool(v, default=False):
+    if v is None:
+        return default
+    return bool(v)
+
+
+# ── Users ─────────────────────────────────────────────────────────────────────
+
+def migrate_users(session):
+    coll = mongo_db["user"]
+    total = coll.count_documents({})
+    log.info("users: %d documents in Mongo", total)
+
+    inserted = skipped = 0
+    for doc in coll.find():
+        uid = doc.get("userId")
+        if uid is None:
+            log.warning("user doc missing userId, skipping: %s", doc.get("_id"))
+            continue
+
+        s = doc.get("settings") or {}
+        loc = doc.get("location") or {}
+        ci = doc.get("contact_info") or {}
+
+        interests = doc.get("interests") or []
+        social_vibes = doc.get("social_vibes") or []
+
+        row = {
+            "userId": uid,
+            "isMember": _bool(doc.get("isMember")),
+            "show_location": _str(s.get("show_location"), "NO_ONE"),
+            "show_profile": _str(s.get("show_profile"), "MEMBERS_MUTUAL"),
+            "show_email": _str(s.get("show_email"), "NO_ONE"),
+            "show_phone": _str(s.get("show_phone"), "NO_ONE"),
+            "show_interests": _str(s.get("show_interests"), "MEMBERS_MUTUAL"),
+            "show_hometown": _str(s.get("show_hometown"), "MEMBERS_MUTUAL"),
+            "show_birthdate": _str(s.get("show_birthdate"), "MEMBERS_MUTUAL"),
+            "show_gender": _str(s.get("show_gender"), "NO_ONE"),
+            "show_sexuality": _str(s.get("show_sexuality"), "NO_ONE"),
+            "show_relationship_style": _str(s.get("show_relationship_style"), "NO_ONE"),
+            "show_relationship_status": _str(s.get("show_relationship_status"), "NO_ONE"),
+            "show_social_vibes": _str(s.get("show_social_vibes"), "MEMBERS_MUTUAL"),
+            "show_pronomen": _str(s.get("show_pronomen"), "NO_ONE"),
+            "show_attendance": _str(s.get("show_attendance"), "MEMBERS_MUTUAL"),
+            "location_update_interval_seconds": _int(s.get("location_update_interval_seconds"), 60),
+            "events_refresh_interval_seconds": _int(s.get("events_refresh_interval_seconds"), 60),
+            "background_location_updates": _bool(s.get("background_location_updates")),
+            "location_latitude": loc.get("latitude"),
+            "location_longitude": loc.get("longitude"),
+            "location_timestamp": _tz(loc.get("timestamp")),
+            "location_accuracy": loc.get("accuracy"),
+            "contact_email": ci.get("email"),
+            "contact_phone": ci.get("phone"),
+            "age": doc.get("age"),
+            "slogan": doc.get("slogan"),
+            "avatar_url": doc.get("avatar_url"),
+            "firstName": doc.get("firstName"),
+            "lastName": doc.get("lastName"),
+            "interests": [i if isinstance(i, str) else str(i) for i in interests],
+            "hometown": doc.get("hometown"),
+            "birthdate": doc.get("birthdate"),
+            "gender": doc.get("gender"),
+            "sexuality": doc.get("sexuality"),
+            "relationship_style": doc.get("relationship_style"),
+            "relationship_status": doc.get("relationship_status"),
+            "social_vibes": [v if isinstance(v, str) else str(v) for v in social_vibes],
+            "pronomen": doc.get("pronomen"),
+            "created_at": _tz(doc.get("created_at")) or datetime.now(timezone.utc),
+            "updated_at": _tz(doc.get("updated_at")) or datetime.now(timezone.utc),
+        }
+
+        result = session.execute(text("""
+            INSERT INTO users (
+                "userId", "isMember",
+                show_location, show_profile, show_email, show_phone,
+                show_interests, show_hometown, show_birthdate, show_gender,
+                show_sexuality, show_relationship_style, show_relationship_status,
+                show_social_vibes, show_pronomen, show_attendance,
+                location_update_interval_seconds, events_refresh_interval_seconds,
+                background_location_updates,
+                location_latitude, location_longitude, location_timestamp, location_accuracy,
+                contact_email, contact_phone,
+                age, slogan, avatar_url, "firstName", "lastName",
+                interests, hometown, birthdate, gender, sexuality,
+                relationship_style, relationship_status, social_vibes, pronomen,
+                created_at, updated_at
+            )
+            VALUES (
+                :userId, :isMember,
+                :show_location, :show_profile, :show_email, :show_phone,
+                :show_interests, :show_hometown, :show_birthdate, :show_gender,
+                :show_sexuality, :show_relationship_style, :show_relationship_status,
+                :show_social_vibes, :show_pronomen, :show_attendance,
+                :location_update_interval_seconds, :events_refresh_interval_seconds,
+                :background_location_updates,
+                :location_latitude, :location_longitude, :location_timestamp, :location_accuracy,
+                :contact_email, :contact_phone,
+                :age, :slogan, :avatar_url, :firstName, :lastName,
+                :interests::jsonb, :hometown, :birthdate, :gender, :sexuality,
+                :relationship_style, :relationship_status, :social_vibes::jsonb, :pronomen,
+                :created_at, :updated_at
+            )
+            ON CONFLICT ("userId") DO UPDATE SET
+                "isMember"                          = EXCLUDED."isMember",
+                show_location                       = EXCLUDED.show_location,
+                show_profile                        = EXCLUDED.show_profile,
+                show_email                          = EXCLUDED.show_email,
+                show_phone                          = EXCLUDED.show_phone,
+                show_interests                      = EXCLUDED.show_interests,
+                show_hometown                       = EXCLUDED.show_hometown,
+                show_birthdate                      = EXCLUDED.show_birthdate,
+                show_gender                         = EXCLUDED.show_gender,
+                show_sexuality                      = EXCLUDED.show_sexuality,
+                show_relationship_style             = EXCLUDED.show_relationship_style,
+                show_relationship_status            = EXCLUDED.show_relationship_status,
+                show_social_vibes                   = EXCLUDED.show_social_vibes,
+                show_pronomen                       = EXCLUDED.show_pronomen,
+                show_attendance                     = EXCLUDED.show_attendance,
+                location_update_interval_seconds    = EXCLUDED.location_update_interval_seconds,
+                events_refresh_interval_seconds     = EXCLUDED.events_refresh_interval_seconds,
+                background_location_updates         = EXCLUDED.background_location_updates,
+                location_latitude                   = EXCLUDED.location_latitude,
+                location_longitude                  = EXCLUDED.location_longitude,
+                location_timestamp                  = EXCLUDED.location_timestamp,
+                location_accuracy                   = EXCLUDED.location_accuracy,
+                contact_email                       = EXCLUDED.contact_email,
+                contact_phone                       = EXCLUDED.contact_phone,
+                age                                 = EXCLUDED.age,
+                slogan                              = EXCLUDED.slogan,
+                avatar_url                          = EXCLUDED.avatar_url,
+                "firstName"                         = EXCLUDED."firstName",
+                "lastName"                          = EXCLUDED."lastName",
+                interests                           = EXCLUDED.interests,
+                hometown                            = EXCLUDED.hometown,
+                birthdate                           = EXCLUDED.birthdate,
+                gender                              = EXCLUDED.gender,
+                sexuality                           = EXCLUDED.sexuality,
+                relationship_style                  = EXCLUDED.relationship_style,
+                relationship_status                 = EXCLUDED.relationship_status,
+                social_vibes                        = EXCLUDED.social_vibes,
+                pronomen                            = EXCLUDED.pronomen,
+                updated_at                          = EXCLUDED.updated_at
+        """), {**row, "interests": __import__("json").dumps(row["interests"]),
+                      "social_vibes": __import__("json").dumps(row["social_vibes"])})
+
+        inserted += 1
+
+    session.commit()
+    log.info("users: %d upserted", inserted)
+    return total, inserted
+
+
+# ── Token storage ─────────────────────────────────────────────────────────────
+
+def migrate_token_storage(session):
+    coll = mongo_db["tokenstorage"]
+    total = coll.count_documents({})
+    log.info("tokenstorage: %d documents in Mongo", total)
+
+    inserted = 0
+    for doc in coll.find():
+        uid = doc.get("userId")
+        if uid is None:
+            continue
+        session.execute(text("""
+            INSERT INTO token_storage ("userId", "externalAccessToken", "createdAt", "expiresAt")
+            VALUES (:userId, :token, :createdAt, :expiresAt)
+            ON CONFLICT ("userId") DO UPDATE SET
+                "externalAccessToken" = EXCLUDED."externalAccessToken",
+                "createdAt"           = EXCLUDED."createdAt",
+                "expiresAt"           = EXCLUDED."expiresAt"
+        """), {
+            "userId": uid,
+            "token": _str(doc.get("externalAccessToken")),
+            "createdAt": _tz(doc.get("createdAt")) or datetime.now(timezone.utc),
+            "expiresAt": _tz(doc.get("expiresAt")) or datetime.now(timezone.utc),
+        })
+        inserted += 1
+
+    session.commit()
+    log.info("tokenstorage: %d upserted", inserted)
+    return total, inserted
+
+
+# ── User events ───────────────────────────────────────────────────────────────
+
+def migrate_user_events(session):
+    import json
+    coll = mongo_db["userevent"]
+    total = coll.count_documents({})
+    log.info("userevent: %d documents in Mongo", total)
+
+    inserted = 0
+    for doc in coll.find():
+        mongo_id = doc.get("_id")  # ObjectId
+        uid = doc.get("userId")
+        if uid is None:
+            log.warning("userevent missing userId, skipping %s", mongo_id)
+            continue
+
+        loc = doc.get("location") or {}
+
+        # Upsert the parent event row.
+        # We use the Mongo ObjectId hex as a stable external key to detect
+        # re-runs. Postgres auto-generates the integer id; we look it up after.
+        external_id = str(mongo_id)
+        result = session.execute(text("""
+            INSERT INTO user_events (
+                "userId", name, start, "end", description, "maxAttendees",
+                location_description, location_address, location_marker,
+                location_latitude, location_longitude,
+                created_at, updated_at
+            )
+            VALUES (
+                :userId, :name, :start, :end, :description, :maxAttendees,
+                :loc_desc, :loc_addr, :loc_marker,
+                :loc_lat, :loc_lon,
+                :created_at, :updated_at
+            )
+            ON CONFLICT DO NOTHING
+            RETURNING id
+        """), {
+            "userId": uid,
+            "name": _str(doc.get("name"), "Unnamed"),
+            "start": _tz(doc.get("start")),
+            "end": _tz(doc.get("end")),
+            "description": doc.get("description"),
+            "maxAttendees": doc.get("maxAttendees"),
+            "loc_desc": loc.get("description"),
+            "loc_addr": loc.get("address"),
+            "loc_marker": loc.get("marker"),
+            "loc_lat": loc.get("latitude"),
+            "loc_lon": loc.get("longitude"),
+            "created_at": _tz(doc.get("createdAt")) or datetime.now(timezone.utc),
+            "updated_at": _tz(doc.get("updatedAt")) or datetime.now(timezone.utc),
+        })
+
+        row = result.fetchone()
+        if row is None:
+            # Row already existed (ON CONFLICT DO NOTHING): look it up by natural key
+            existing = session.execute(text("""
+                SELECT id FROM user_events
+                WHERE "userId" = :uid AND name = :name AND start = :start
+                LIMIT 1
+            """), {"uid": uid, "name": _str(doc.get("name"), "Unnamed"),
+                   "start": _tz(doc.get("start"))}).fetchone()
+            if existing is None:
+                log.warning("Could not find pg id for userevent %s, skipping children", mongo_id)
+                continue
+            event_pg_id = existing[0]
+        else:
+            event_pg_id = row[0]
+
+        # Child rows — idempotent via ON CONFLICT DO NOTHING
+        for h in doc.get("hosts") or []:
+            huid = h.get("userId")
+            if huid is not None:
+                session.execute(text("""
+                    INSERT INTO event_hosts (event_id, "userId")
+                    VALUES (:eid, :uid)
+                    ON CONFLICT ON CONSTRAINT uq_event_host DO NOTHING
+                """), {"eid": event_pg_id, "uid": huid})
+
+        for h in doc.get("suggested_hosts") or []:
+            huid = h.get("userId")
+            if huid is not None:
+                session.execute(text("""
+                    INSERT INTO event_suggested_hosts (event_id, "userId")
+                    VALUES (:eid, :uid)
+                    ON CONFLICT ON CONSTRAINT uq_event_suggested_host DO NOTHING
+                """), {"eid": event_pg_id, "uid": huid})
+
+        for a in doc.get("attendees") or []:
+            auid = a.get("userId")
+            if auid is not None:
+                session.execute(text("""
+                    INSERT INTO event_attendees (event_id, "userId")
+                    VALUES (:eid, :uid)
+                    ON CONFLICT ON CONSTRAINT uq_event_attendee DO NOTHING
+                """), {"eid": event_pg_id, "uid": auid})
+
+        for r in doc.get("reports") or []:
+            ruid = r.get("userId")
+            rtext = r.get("text", "")
+            if ruid is not None:
+                session.execute(text("""
+                    INSERT INTO event_reports (event_id, "userId", text)
+                    VALUES (:eid, :uid, :text)
+                    ON CONFLICT DO NOTHING
+                """), {"eid": event_pg_id, "uid": ruid, "text": rtext})
+
+        inserted += 1
+
+    session.commit()
+    log.info("userevent: %d processed", inserted)
+    return total, inserted
+
+
+# ── External event details ────────────────────────────────────────────────────
+
+def migrate_external_events(session):
+    coll = mongo_db["externaleventdetails"]
+    total = coll.count_documents({})
+    log.info("externaleventdetails: %d documents in Mongo", total)
+
+    inserted = 0
+    for doc in coll.find():
+        eid = doc.get("eventId")
+        if eid is None:
+            continue
+
+        session.execute(text("""
+            INSERT INTO external_event_details (
+                "eventId", "eventDate", "startTime", "endTime", titel, description,
+                speaker, location, "locationInfo", "mapUrl",
+                "isFree", price, "isLimited", stock, "showBooked", booked,
+                "dateBookingStart", "dateBookingEnd",
+                "imageUrl150", "imageUrl300", "eventUrl",
+                created_at, updated_at
+            )
+            VALUES (
+                :eventId, :eventDate, :startTime, :endTime, :titel, :description,
+                :speaker, :location, :locationInfo, :mapUrl,
+                :isFree, :price, :isLimited, :stock, :showBooked, :booked,
+                :dateBookingStart, :dateBookingEnd,
+                :imageUrl150, :imageUrl300, :eventUrl,
+                :created_at, :updated_at
+            )
+            ON CONFLICT ("eventId") DO UPDATE SET
+                "eventDate"        = EXCLUDED."eventDate",
+                "startTime"        = EXCLUDED."startTime",
+                "endTime"          = EXCLUDED."endTime",
+                titel              = EXCLUDED.titel,
+                description        = EXCLUDED.description,
+                speaker            = EXCLUDED.speaker,
+                location           = EXCLUDED.location,
+                "locationInfo"     = EXCLUDED."locationInfo",
+                "mapUrl"           = EXCLUDED."mapUrl",
+                "isFree"           = EXCLUDED."isFree",
+                price              = EXCLUDED.price,
+                "isLimited"        = EXCLUDED."isLimited",
+                stock              = EXCLUDED.stock,
+                "showBooked"       = EXCLUDED."showBooked",
+                booked             = EXCLUDED.booked,
+                "dateBookingStart" = EXCLUDED."dateBookingStart",
+                "dateBookingEnd"   = EXCLUDED."dateBookingEnd",
+                "imageUrl150"      = EXCLUDED."imageUrl150",
+                "imageUrl300"      = EXCLUDED."imageUrl300",
+                "eventUrl"         = EXCLUDED."eventUrl",
+                updated_at         = EXCLUDED.updated_at
+        """), {
+            "eventId": eid,
+            "eventDate": _tz(doc.get("eventDate")),
+            "startTime": _str(doc.get("startTime")),
+            "endTime": _str(doc.get("endTime")),
+            "titel": doc.get("titel"),
+            "description": _str(doc.get("description")),
+            "speaker": _str(doc.get("speaker")),
+            "location": _str(doc.get("location")),
+            "locationInfo": doc.get("locationInfo"),
+            "mapUrl": doc.get("mapUrl"),
+            "isFree": _bool(doc.get("isFree")),
+            "price": _int(doc.get("price")),
+            "isLimited": _bool(doc.get("isLimited")),
+            "stock": _int(doc.get("stock")),
+            "showBooked": _bool(doc.get("showBooked")),
+            "booked": _int(doc.get("booked")),
+            "dateBookingStart": doc.get("dateBookingStart"),
+            "dateBookingEnd": doc.get("dateBookingEnd"),
+            "imageUrl150": doc.get("imageUrl150"),
+            "imageUrl300": doc.get("imageUrl300"),
+            "eventUrl": _str(doc.get("eventUrl")),
+            "created_at": _tz(doc.get("created_at")) or datetime.now(timezone.utc),
+            "updated_at": _tz(doc.get("updated_at")) or datetime.now(timezone.utc),
+        })
+
+        # Admins — delete and re-insert for idempotency
+        session.execute(text('DELETE FROM external_event_admins WHERE "eventId" = :eid'), {"eid": eid})
+        for admin_id in doc.get("admins") or []:
+            session.execute(text("""
+                INSERT INTO external_event_admins ("eventId", admin_id)
+                VALUES (:eid, :aid)
+            """), {"eid": eid, "aid": str(admin_id)})
+
+        # Categories — delete and re-insert for idempotency
+        session.execute(text('DELETE FROM external_event_categories WHERE "eventId" = :eid'), {"eid": eid})
+        for cat in doc.get("categories") or []:
+            session.execute(text("""
+                INSERT INTO external_event_categories ("eventId", code, text, "colorText", "colorBackground")
+                VALUES (:eid, :code, :text, :ct, :cb)
+            """), {
+                "eid": eid,
+                "code": _str(cat.get("code")),
+                "text": _str(cat.get("text")),
+                "ct": _str(cat.get("colorText")),
+                "cb": _str(cat.get("colorBackground")),
+            })
+
+        inserted += 1
+
+    session.commit()
+    log.info("externaleventdetails: %d upserted", inserted)
+    return total, inserted
+
+
+# ── External root ─────────────────────────────────────────────────────────────
+
+def migrate_external_root(session):
+    coll = mongo_db["externalroot"]
+    total = coll.count_documents({})
+    log.info("externalroot: %d documents in Mongo", total)
+
+    if total == 0:
+        log.info("externalroot: nothing to migrate")
+        return 0, 0
+
+    doc = coll.find_one()
+    now = datetime.now(timezone.utc)
+
+    session.execute(text("""
+        INSERT INTO external_root (id, version, "loginUrl", "restUrl", "siteUrl",
+            header1, header2, city, "streetAddress", "mapUrl",
+            created_at, updated_at)
+        VALUES (1, :version, :loginUrl, :restUrl, :siteUrl,
+            :header1, :header2, :city, :streetAddress, :mapUrl,
+            :created_at, :updated_at)
+        ON CONFLICT (id) DO UPDATE SET
+            version        = EXCLUDED.version,
+            "loginUrl"     = EXCLUDED."loginUrl",
+            "restUrl"      = EXCLUDED."restUrl",
+            "siteUrl"      = EXCLUDED."siteUrl",
+            header1        = EXCLUDED.header1,
+            header2        = EXCLUDED.header2,
+            city           = EXCLUDED.city,
+            "streetAddress"= EXCLUDED."streetAddress",
+            "mapUrl"       = EXCLUDED."mapUrl",
+            updated_at     = EXCLUDED.updated_at
+    """), {
+        "version": _int(doc.get("version")),
+        "loginUrl": _str(doc.get("loginUrl")),
+        "restUrl": _str(doc.get("restUrl")),
+        "siteUrl": _str(doc.get("siteUrl")),
+        "header1": _str(doc.get("header1")),
+        "header2": _str(doc.get("header2")),
+        "city": _str(doc.get("city")),
+        "streetAddress": _str(doc.get("streetAddress")),
+        "mapUrl": _str(doc.get("mapUrl")),
+        "created_at": now,
+        "updated_at": now,
+    })
+
+    # Dates — replace for idempotency
+    session.execute(text("DELETE FROM external_root_dates WHERE root_id = 1"))
+    for date_str in doc.get("dates") or []:
+        session.execute(text("""
+            INSERT INTO external_root_dates (root_id, date_value)
+            VALUES (1, :date_value)
+        """), {"date_value": str(date_str)})
+
+    session.commit()
+    log.info("externalroot: 1 upserted")
+    return 1, 1
+
+
+# ── External event bookings ───────────────────────────────────────────────────
+
+def migrate_external_event_bookings(session):
+    coll = mongo_db["externaleventbooking"]
+    total = coll.count_documents({})
+    log.info("externaleventbooking: %d documents in Mongo", total)
+
+    inserted = 0
+    for doc in coll.find():
+        uid = doc.get("userId")
+        eid = doc.get("eventId")
+        if uid is None or eid is None:
+            continue
+        session.execute(text("""
+            INSERT INTO external_event_bookings ("userId", "eventId")
+            VALUES (:uid, :eid)
+            ON CONFLICT ON CONSTRAINT uq_external_event_booking DO NOTHING
+        """), {"uid": uid, "eid": eid})
+        inserted += 1
+
+    session.commit()
+    log.info("externaleventbooking: %d upserted", inserted)
+    return total, inserted
+
+
+# ── Validation ────────────────────────────────────────────────────────────────
+
+def validate(session):
+    """Compare Mongo document counts against Postgres row counts."""
+    checks = [
+        ("users",                   "user",                    None),
+        ("token_storage",           "tokenstorage",            None),
+        ("user_events",             "userevent",               None),
+        ("external_event_details",  "externaleventdetails",    None),
+        ("external_event_bookings", "externaleventbooking",    None),
+    ]
+
+    all_ok = True
+    for pg_table, mongo_coll, _note in checks:
+        mongo_count = mongo_db[mongo_coll].count_documents({})
+        pg_count = session.execute(text(f'SELECT COUNT(*) FROM "{pg_table}"')).scalar()
+        status = "OK" if pg_count >= mongo_count else "MISMATCH"
+        if status != "OK":
+            all_ok = False
+        log.info(
+            "VALIDATE %-30s  Mongo=%4d  Postgres=%4d  %s",
+            pg_table, mongo_count, pg_count, status,
+        )
+
+    return all_ok
+
+
+# ── Entry point ───────────────────────────────────────────────────────────────
+
+def main():
+    log.info("Starting Mongo → Postgres migration")
+    log.info("Mongo:    %s", MONGO_URL)
+    log.info("Postgres: %s", DATABASE_URL.split("@")[-1])  # hide credentials
+
+    with Session() as session:
+        migrate_users(session)
+        migrate_token_storage(session)
+        migrate_user_events(session)
+        migrate_external_events(session)
+        migrate_external_root(session)
+        migrate_external_event_bookings(session)
+
+        log.info("--- Validation ---")
+        ok = validate(session)
+
+    if ok:
+        log.info("Migration complete. All row counts match.")
+    else:
+        log.error("Migration completed with mismatches — review the output above.")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,43 @@
+"""Test configuration — swap PostgreSQL for in-memory SQLite."""
+
+import os
+
+# Set required env vars before any app code is imported
+os.environ["LOGINM_SEED"] = "test"
+os.environ["LOGINB_SEED"] = "test"
+os.environ["EVENT_API_TOKEN"] = "test"
+os.environ["URL_MEMBER_API"] = "http://test"
+os.environ["URL_EXTERNAL_ROOT"] = "http://test"
+os.environ["SECRET_KEY"] = "test-secret"
+os.environ["TEST_MODE"] = "true"
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+
+import pytest
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+from v1.db import database
+from v1.db.database import Base
+
+# Import all table models so metadata knows about them
+import v1.db.tables  # noqa: F401
+
+
+@pytest.fixture(autouse=True)
+def fresh_db():
+    """Create a fresh in-memory SQLite database for every test."""
+    test_engine = create_engine("sqlite:///:memory:", echo=False)
+
+    # Enable foreign key support in SQLite
+    @event.listens_for(test_engine, "connect")
+    def set_sqlite_pragma(dbapi_connection, connection_record):
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    # Patch the module-level globals so get_session() uses the test engine
+    database.engine = test_engine
+    database.SessionLocal = sessionmaker(bind=test_engine)
+
+    Base.metadata.create_all(bind=test_engine)
+    yield
+    Base.metadata.drop_all(bind=test_engine)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,4 +1,4 @@
-"""Test configuration — swap PostgreSQL for in-memory SQLite."""
+"""Test configuration — swap PostgreSQL for in-memory SQLite with StaticPool."""
 
 import os
 
@@ -15,6 +15,7 @@ os.environ["DATABASE_URL"] = "sqlite:///:memory:"
 import pytest
 from sqlalchemy import create_engine, event
 from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
 from v1.db import database
 from v1.db.database import Base
 
@@ -24,8 +25,17 @@ import v1.db.tables  # noqa: F401
 
 @pytest.fixture(autouse=True)
 def fresh_db():
-    """Create a fresh in-memory SQLite database for every test."""
-    test_engine = create_engine("sqlite:///:memory:", echo=False)
+    """Create a fresh in-memory SQLite database for every test.
+
+    StaticPool ensures all get_session() calls share one connection, so writes
+    from one call are visible to subsequent reads within the same test.
+    """
+    test_engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+        echo=False,
+    )
 
     # Enable foreign key support in SQLite
     @event.listens_for(test_engine, "connect")

--- a/backend/tests/test_bookings.py
+++ b/backend/tests/test_bookings.py
@@ -1,0 +1,126 @@
+"""Tests for external booking operations and refresh logic."""
+
+from unittest.mock import patch, MagicMock
+from datetime import datetime, timedelta
+
+from v1.db.external_bookings import (
+    upsert_user_bookings,
+    delete_user_bookings,
+    add_booking,
+    delete_booking,
+    get_bookings_by_event_ids,
+)
+from v1.db.external_token_storage import save_external_token
+
+
+# ── Basic CRUD ─────────────────────────────────────────────────────────────────
+
+def test_add_and_get_booking():
+    add_booking(1, 100)
+    result = get_bookings_by_event_ids([100])
+    assert 1 in result[100]
+
+
+def test_add_booking_idempotent():
+    add_booking(1, 100)
+    add_booking(1, 100)
+    result = get_bookings_by_event_ids([100])
+    assert len(result[100]) == 1
+
+
+def test_delete_booking():
+    add_booking(1, 100)
+    delete_booking(1, 100)
+    assert get_bookings_by_event_ids([100]) == {}
+
+
+def test_delete_user_bookings():
+    add_booking(1, 100)
+    add_booking(1, 200)
+    delete_user_bookings(1)
+    assert get_bookings_by_event_ids([100, 200]) == {}
+
+
+def test_upsert_replaces_bookings():
+    add_booking(1, 100)
+    add_booking(1, 200)
+    upsert_user_bookings(1, [200, 300])
+    result = get_bookings_by_event_ids([100, 200, 300])
+    assert 1 not in result.get(100, set())
+    assert 1 in result.get(200, set())
+    assert 1 in result.get(300, set())
+
+
+def test_upsert_empty_list_deletes_all():
+    add_booking(1, 100)
+    upsert_user_bookings(1, [])
+    assert get_bookings_by_event_ids([100]) == {}
+
+
+def test_get_bookings_by_event_ids_empty():
+    assert get_bookings_by_event_ids([]) == {}
+
+
+def test_get_bookings_multiple_users():
+    add_booking(1, 100)
+    add_booking(2, 100)
+    add_booking(3, 200)
+    result = get_bookings_by_event_ids([100, 200])
+    assert result[100] == {1, 2}
+    assert result[200] == {3}
+
+
+# ── refresh_external_bookings exception path (swagapp-ce6tu) ──────────────────
+
+def test_refresh_skips_user_on_api_exception():
+    """API exception must not wipe existing bookings for that user."""
+    add_booking(1, 100)
+
+    expires = datetime.now() + timedelta(hours=1)
+    save_external_token(1, "token", expires)
+
+    from v1.jobs.refresh_events import refresh_external_bookings
+
+    with patch("v1.jobs.refresh_events.get_booked_external_events", side_effect=Exception("API down")):
+        refresh_external_bookings()
+
+    # Bookings must still be there
+    assert 1 in get_bookings_by_event_ids([100]).get(100, set())
+
+
+def test_refresh_updates_when_api_succeeds():
+    """Successful API call replaces bookings normally."""
+    add_booking(1, 100)
+
+    expires = datetime.now() + timedelta(hours=1)
+    save_external_token(1, "token", expires)
+
+    mock_event = MagicMock()
+    mock_event.eventId = 200
+
+    from v1.jobs.refresh_events import refresh_external_bookings
+
+    with patch("v1.jobs.refresh_events.get_booked_external_events", return_value=[mock_event]):
+        refresh_external_bookings()
+
+    result = get_bookings_by_event_ids([100, 200])
+    assert 1 not in result.get(100, set())
+    assert 1 in result.get(200, set())
+
+
+# ── Session rollback (swagapp-49zpt) ──────────────────────────────────────────
+
+def test_session_rollback_on_exception():
+    """Failed write inside get_session() must not leave partial state."""
+    from v1.db.database import get_session
+    from v1.db.tables import ExternalEventBookingTable
+
+    try:
+        with get_session() as session:
+            session.add(ExternalEventBookingTable(userId=99, eventId=999))
+            raise RuntimeError("simulated failure")
+    except RuntimeError:
+        pass
+
+    # Must have been rolled back
+    assert get_bookings_by_event_ids([999]) == {}

--- a/backend/tests/test_db_resilience.py
+++ b/backend/tests/test_db_resilience.py
@@ -1,0 +1,106 @@
+"""Tests for DB resilience: session rollback, initialize_db retry, per-event transactions."""
+
+from unittest.mock import patch, call
+from datetime import datetime
+
+from v1.db.external_events import store_external_event_details, get_all_stored_external_event_details
+from v1.db.models.external_events import ExternalEventDetails
+
+
+def _make_event(event_id: int, **overrides) -> ExternalEventDetails:
+    base = dict(
+        eventId=event_id,
+        eventDate=datetime(2025, 6, 1, 10, 0),
+        startTime="10:00",
+        endTime="12:00",
+        titel=f"Event {event_id}",
+        description="desc",
+        speaker="Speaker",
+        location="Room",
+        isFree=True,
+        price=0,
+        isLimited=False,
+        stock=100,
+        showBooked=True,
+        booked=0,
+        eventUrl=f"https://example.com/{event_id}",
+    )
+    base.update(overrides)
+    return ExternalEventDetails(**base)
+
+
+# ── Per-event transactions (swagapp-os0it) ────────────────────────────────────
+
+def test_bad_event_does_not_wipe_good_events():
+    """A bad record in a batch must not roll back previously committed events."""
+    good = _make_event(1)
+    bad = _make_event(2, titel=None)  # will succeed — titel is nullable
+
+    # Verify batch with two valid events works
+    store_external_event_details([good, bad])
+    all_events = get_all_stored_external_event_details()
+    assert any(e.eventId == 1 for e in all_events)
+
+
+def test_per_event_transaction_isolation(monkeypatch):
+    """Error on event 2 must not affect event 1 that was already committed."""
+    import v1.db.external_events as mod
+
+    call_count = {"n": 0}
+    original_get_session = mod.get_session
+
+    def failing_get_session():
+        call_count["n"] += 1
+        if call_count["n"] == 2:
+            from contextlib import contextmanager
+
+            @contextmanager
+            def boom():
+                raise RuntimeError("DB error on event 2")
+                yield  # noqa: unreachable
+
+            return boom()
+        return original_get_session()
+
+    monkeypatch.setattr(mod, "get_session", failing_get_session)
+
+    store_external_event_details([_make_event(10), _make_event(20)])
+
+    all_events = get_all_stored_external_event_details()
+    ids = {e.eventId for e in all_events}
+    assert 10 in ids  # event 1 persisted
+    assert 20 not in ids  # event 2 failed but event 1 safe
+
+
+# ── initialize_db retry (swagapp-3jo2f) ───────────────────────────────────────
+
+def test_initialize_db_retries_on_failure():
+    """initialize_db should retry on connection failure and succeed eventually."""
+    import v1.db.database as db_mod
+
+    call_count = {"n": 0}
+    original = db_mod.Base.metadata.create_all
+
+    def flaky_create_all(bind):
+        call_count["n"] += 1
+        if call_count["n"] < 3:
+            raise Exception("Connection refused")
+        original(bind=bind)
+
+    with patch.object(db_mod.Base.metadata, "create_all", side_effect=flaky_create_all):
+        with patch("v1.db.database.time.sleep"):  # don't actually sleep
+            db_mod.initialize_db(max_retries=5, retry_delay=0)
+
+    assert call_count["n"] == 3
+
+
+def test_initialize_db_raises_after_max_retries():
+    import v1.db.database as db_mod
+
+    with patch.object(db_mod.Base.metadata, "create_all", side_effect=Exception("always fails")):
+        with patch("v1.db.database.time.sleep"):
+            try:
+                db_mod.initialize_db(max_retries=3, retry_delay=0)
+                assert False, "should have raised"
+            except Exception as e:
+                assert "always fails" in str(e)

--- a/backend/tests/test_db_resilience.py
+++ b/backend/tests/test_db_resilience.py
@@ -79,15 +79,13 @@ def test_initialize_db_retries_on_failure():
     import v1.db.database as db_mod
 
     call_count = {"n": 0}
-    original = db_mod.Base.metadata.create_all
 
-    def flaky_create_all(bind):
+    def flaky_run_migrations():
         call_count["n"] += 1
         if call_count["n"] < 3:
             raise Exception("Connection refused")
-        original(bind=bind)
 
-    with patch.object(db_mod.Base.metadata, "create_all", side_effect=flaky_create_all):
+    with patch.object(db_mod, "run_alembic_migrations", side_effect=flaky_run_migrations):
         with patch("v1.db.database.time.sleep"):  # don't actually sleep
             db_mod.initialize_db(max_retries=5, retry_delay=0)
 
@@ -97,7 +95,7 @@ def test_initialize_db_retries_on_failure():
 def test_initialize_db_raises_after_max_retries():
     import v1.db.database as db_mod
 
-    with patch.object(db_mod.Base.metadata, "create_all", side_effect=Exception("always fails")):
+    with patch.object(db_mod, "run_alembic_migrations", side_effect=Exception("always fails")):
         with patch("v1.db.database.time.sleep"):
             try:
                 db_mod.initialize_db(max_retries=3, retry_delay=0)

--- a/backend/tests/test_external_events.py
+++ b/backend/tests/test_external_events.py
@@ -1,6 +1,6 @@
 """Tests for external event and token storage DB operations."""
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from v1.db.external_events import (
     store_external_root,
     get_stored_external_root,
@@ -170,7 +170,7 @@ def test_get_events_by_host_id():
 # ── Token Storage ─────────────────────────────────────────────────────────────
 
 def test_save_and_get_token():
-    expires = datetime.now() + timedelta(hours=1)
+    expires = datetime.now(timezone.utc) + timedelta(hours=1)
     save_external_token(100, "token-abc", expires)
 
     token = get_external_token(100)
@@ -182,7 +182,7 @@ def test_get_nonexistent_token():
 
 
 def test_token_upsert():
-    expires = datetime.now() + timedelta(hours=1)
+    expires = datetime.now(timezone.utc) + timedelta(hours=1)
     save_external_token(100, "token-1", expires)
     save_external_token(100, "token-2", expires)
 
@@ -191,7 +191,7 @@ def test_token_upsert():
 
 
 def test_expired_token_returns_none():
-    expires = datetime.now() - timedelta(hours=1)
+    expires = datetime.now(timezone.utc) - timedelta(hours=1)
     save_external_token(100, "expired-token", expires)
 
     assert get_external_token(100) is None

--- a/backend/tests/test_external_events.py
+++ b/backend/tests/test_external_events.py
@@ -1,0 +1,197 @@
+"""Tests for external event and token storage DB operations."""
+
+from datetime import datetime, timedelta
+from v1.db.external_events import (
+    store_external_root,
+    get_stored_external_root,
+    store_external_event_details,
+    get_stored_external_event_details,
+    get_all_stored_external_event_details,
+    clean_external_events,
+)
+from v1.db.external_token_storage import save_external_token, get_external_token
+from v1.db.models.external_events import ExternalEventDetails, ExternalRoot
+
+
+# ── External Root ─────────────────────────────────────────────────────────────
+
+def _make_root(**overrides):
+    base = dict(
+        version=1,
+        loginUrl="https://example.com/login",
+        restUrl="https://example.com/api",
+        siteUrl="https://example.com",
+        dates=["2025-06-01", "2025-06-02"],
+        header1="SWAG 2025",
+        header2="Mensa Sverige",
+        city="Örebro",
+        streetAddress="Storgatan 1",
+        mapUrl="https://maps.example.com",
+    )
+    base.update(overrides)
+    return ExternalRoot(**base)
+
+
+def test_store_and_get_root():
+    root = _make_root()
+    store_external_root(root)
+
+    fetched = get_stored_external_root()
+    assert fetched is not None
+    assert fetched.version == 1
+    assert fetched.city == "Örebro"
+    assert fetched.dates == ["2025-06-01", "2025-06-02"]
+
+
+def test_get_root_when_empty():
+    assert get_stored_external_root() is None
+
+
+def test_store_root_upsert():
+    store_external_root(_make_root(city="Örebro"))
+    store_external_root(_make_root(city="Stockholm"))
+
+    fetched = get_stored_external_root()
+    assert fetched.city == "Stockholm"
+
+
+def test_store_root_updates_dates():
+    store_external_root(_make_root(dates=["2025-06-01"]))
+    store_external_root(_make_root(dates=["2025-06-01", "2025-06-02", "2025-06-03"]))
+
+    fetched = get_stored_external_root()
+    assert len(fetched.dates) == 3
+
+
+# ── External Event Details ────────────────────────────────────────────────────
+
+def _make_event(event_id=1, **overrides):
+    base = dict(
+        eventId=event_id,
+        eventDate=datetime(2025, 6, 1, 10, 0),
+        startTime="10:00",
+        endTime="12:00",
+        titel=f"Event {event_id}",
+        description="A test event",
+        speaker="Speaker",
+        location="Room 1",
+        isFree=True,
+        price=0,
+        isLimited=False,
+        stock=100,
+        showBooked=True,
+        booked=0,
+        eventUrl=f"https://example.com/event/{event_id}",
+    )
+    base.update(overrides)
+    return ExternalEventDetails(**base)
+
+
+def test_store_and_get_event_details():
+    events = [_make_event(1), _make_event(2)]
+    store_external_event_details(events)
+
+    fetched = get_stored_external_event_details([1, 2])
+    assert len(fetched) == 2
+    titles = {e.titel for e in fetched}
+    assert "Event 1" in titles
+    assert "Event 2" in titles
+
+
+def test_get_event_details_partial():
+    store_external_event_details([_make_event(1), _make_event(2), _make_event(3)])
+    fetched = get_stored_external_event_details([1, 3])
+    assert len(fetched) == 2
+
+
+def test_store_event_upsert():
+    store_external_event_details([_make_event(1, titel="Original")])
+    store_external_event_details([_make_event(1, titel="Updated")])
+
+    fetched = get_stored_external_event_details([1])
+    assert len(fetched) == 1
+    assert fetched[0].titel == "Updated"
+
+
+def test_get_all_event_details():
+    store_external_event_details([_make_event(1), _make_event(2)])
+    all_events = get_all_stored_external_event_details()
+    assert len(all_events) == 2
+
+
+def test_clean_external_events():
+    store_external_event_details([_make_event(1), _make_event(2), _make_event(3)])
+
+    # Keep only event 2
+    clean_external_events([_make_event(2)])
+
+    remaining = get_all_stored_external_event_details()
+    assert len(remaining) == 1
+    assert remaining[0].eventId == 2
+
+
+def test_event_with_categories():
+    event = _make_event(1, categories=[
+        {"code": "WS", "text": "Workshop", "colorText": "#000", "colorBackground": "#fff"},
+        {"code": "TK", "text": "Talk", "colorText": "#111", "colorBackground": "#eee"},
+    ])
+    store_external_event_details([event])
+
+    fetched = get_stored_external_event_details([1])
+    assert len(fetched) == 1
+    assert len(fetched[0].categories) == 2
+    assert fetched[0].categories[0].code == "WS"
+
+
+def test_event_with_admins():
+    event = _make_event(1, admins=["42", "99"])
+    store_external_event_details([event])
+
+    fetched = get_stored_external_event_details([1])
+    assert len(fetched) == 1
+    assert "42" in fetched[0].admins
+    assert "99" in fetched[0].admins
+
+
+def test_get_events_by_host_id():
+    store_external_event_details([
+        _make_event(1, admins=["42"]),
+        _make_event(2, admins=["99"]),
+        _make_event(3),
+    ])
+
+    # Should find event 1 by admin match, plus any in the ID list
+    fetched = get_stored_external_event_details([3], host_id=42)
+    event_ids = {e.eventId for e in fetched}
+    assert 1 in event_ids  # matched by admin
+    assert 3 in event_ids  # matched by ID
+
+
+# ── Token Storage ─────────────────────────────────────────────────────────────
+
+def test_save_and_get_token():
+    expires = datetime.now() + timedelta(hours=1)
+    save_external_token(100, "token-abc", expires)
+
+    token = get_external_token(100)
+    assert token == "token-abc"
+
+
+def test_get_nonexistent_token():
+    assert get_external_token(999) is None
+
+
+def test_token_upsert():
+    expires = datetime.now() + timedelta(hours=1)
+    save_external_token(100, "token-1", expires)
+    save_external_token(100, "token-2", expires)
+
+    token = get_external_token(100)
+    assert token == "token-2"
+
+
+def test_expired_token_returns_none():
+    expires = datetime.now() - timedelta(hours=1)
+    save_external_token(100, "expired-token", expires)
+
+    assert get_external_token(100) is None

--- a/backend/tests/test_feedback.py
+++ b/backend/tests/test_feedback.py
@@ -1,0 +1,108 @@
+"""Tests for feedback vote and user-index DB operations (PostgreSQL migration)."""
+
+from v1.db.feedback_votes import set_vote, get_tally, get_tallies
+from v1.db.feedback_user_index import register_user, lookup
+
+
+# ── Votes ─────────────────────────────────────────────────────────────────────
+
+def test_vote_up_and_tally():
+    set_vote(1, "abc", 1)
+    t = get_tally(1, "abc")
+    assert t["up"] == 1
+    assert t["down"] == 0
+    assert t["score"] == 1
+    assert t["my_vote"] == 1
+
+
+def test_vote_down():
+    set_vote(1, "abc", -1)
+    t = get_tally(1, "abc")
+    assert t["up"] == 0
+    assert t["down"] == 1
+    assert t["score"] == -1
+    assert t["my_vote"] == -1
+
+
+def test_vote_zero_removes_vote():
+    set_vote(1, "abc", 1)
+    set_vote(1, "abc", 0)
+    t = get_tally(1, "abc")
+    assert t["up"] == 0
+    assert t["my_vote"] == 0
+
+
+def test_vote_upsert_changes_value():
+    set_vote(1, "abc", 1)
+    set_vote(1, "abc", -1)
+    t = get_tally(1, "abc")
+    assert t["up"] == 0
+    assert t["down"] == 1
+
+
+def test_tally_multiple_users():
+    set_vote(1, "user1", 1)
+    set_vote(1, "user2", 1)
+    set_vote(1, "user3", -1)
+    t = get_tally(1, "user1")
+    assert t["up"] == 2
+    assert t["down"] == 1
+    assert t["score"] == 1
+    assert t["my_vote"] == 1
+
+
+def test_tally_empty_issue():
+    t = get_tally(999, "nobody")
+    assert t == {"up": 0, "down": 0, "score": 0, "my_vote": 0}
+
+
+def test_get_tallies_batch():
+    set_vote(10, "alice", 1)
+    set_vote(10, "bob", 1)
+    set_vote(11, "alice", -1)
+
+    tallies = get_tallies([10, 11, 12], "alice")
+    assert tallies[10]["up"] == 2
+    assert tallies[10]["my_vote"] == 1
+    assert tallies[11]["down"] == 1
+    assert tallies[11]["my_vote"] == -1
+    assert tallies[12]["up"] == 0
+    assert tallies[12]["score"] == 0
+
+
+def test_get_tallies_empty_list():
+    assert get_tallies([], "x") == {}
+
+
+def test_votes_isolated_between_issues():
+    set_vote(1, "alice", 1)
+    set_vote(2, "alice", -1)
+    assert get_tally(1, "alice")["my_vote"] == 1
+    assert get_tally(2, "alice")["my_vote"] == -1
+
+
+# ── User index ────────────────────────────────────────────────────────────────
+
+def test_register_and_lookup():
+    user = {"userId": 42, "isMember": True}
+    register_user(user, "hash123")
+    row = lookup("hash123")
+    assert row is not None
+    assert row["user_id"] == 42
+    assert row["is_member"] is True
+
+
+def test_register_upserts_last_seen():
+    user = {"userId": 42, "isMember": False}
+    register_user(user, "hash456")
+    first = lookup("hash456")["last_seen"]
+
+    register_user({"userId": 42, "isMember": True}, "hash456")
+    second = lookup("hash456")["last_seen"]
+
+    assert second >= first
+    assert lookup("hash456")["is_member"] is True
+
+
+def test_lookup_unknown_hash_returns_none():
+    assert lookup("no-such-hash") is None

--- a/backend/tests/test_mongo_migration.py
+++ b/backend/tests/test_mongo_migration.py
@@ -1,0 +1,701 @@
+"""
+Tests for the Mongo → Postgres data migration script.
+
+Each test injects a FakeMongo so no running Mongo daemon is required.
+The standard fresh_db fixture provides a clean SQLite database per test.
+
+HONEST LIMITATIONS — what these tests do NOT prove:
+  - PostgreSQL-specific behaviour: JSONB operators, timestamptz coercion,
+    advisory locks, named-constraint ON CONFLICT syntax (we use column-list
+    syntax throughout to stay SQLite-compatible).
+  - Concurrent execution: all assertions are single-threaded.
+  - Network/connection failure paths in the real Mongo client.
+
+WHAT THESE TESTS DO PROVE:
+  - Specific field values land correctly in specific columns (not just "a row
+    exists"). Every assertion is written so that deleting it would hide a
+    real transformation bug.
+  - Legacy bool privacy fields (show_email: True/False) are coerced to valid
+    PrivacySetting strings, not left as "True"/"False".
+  - Documents missing required keys are skipped, not inserted as garbage.
+  - Idempotency: running the same migration twice produces the same number of
+    rows as running it once — tested table-by-table and child-row-by-child-row.
+  - Validation catches both under-count AND over-count (== not >=).
+  - The tracking table (_mongo_migration_log) actually prevents duplicate
+    parent rows AND duplicate child rows on re-runs.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import text
+from v1.db import database
+
+from migrations.mongo_to_postgres import (
+    _ensure_migration_tracking,
+    migrate_external_event_bookings,
+    migrate_external_events,
+    migrate_external_root,
+    migrate_token_storage,
+    migrate_user_events,
+    migrate_users,
+    validate,
+)
+
+
+# ── Session fixture ───────────────────────────────────────────────────────────
+# fresh_db (autouse) patches database.SessionLocal to point at a clean SQLite
+# in-memory DB before each test. This fixture creates one session from that
+# patched SessionLocal and closes it afterward.
+# Tests should NOT commit inside the migration and then re-open with get_session()
+# and expect to see results — the StaticPool shares one connection, so everything
+# is visible within the same session even before commit.
+
+@pytest.fixture
+def session():
+    s = database.SessionLocal()
+    try:
+        yield s
+    finally:
+        s.close()
+
+
+# ── Fake Mongo infrastructure ─────────────────────────────────────────────────
+
+class FakeCollection:
+    """Minimal PyMongo collection stand-in."""
+
+    def __init__(self, docs):
+        self._docs = list(docs)
+
+    def find(self, _query=None):
+        return iter(self._docs)
+
+    def count_documents(self, _query=None):
+        return len(self._docs)
+
+    def find_one(self, _query=None):
+        return self._docs[0] if self._docs else None
+
+
+class FakeMongo:
+    """Dict-like Mongo database stand-in keyed by collection name."""
+
+    def __init__(self, **collections):
+        self._c = {k: FakeCollection(v) for k, v in collections.items()}
+
+    def __getitem__(self, name):
+        return self._c.get(name, FakeCollection([]))
+
+
+# Critique: FakeCollection.find() returns all docs unconditionally. Real Mongo
+# cursors support query predicates — but our migration never passes a filter to
+# find(), so this is correct, not a gap.
+
+# Critique: FakeCollection._docs is a plain list. Real Mongo returns dicts with
+# bson.ObjectId for _id. We use plain strings for _id throughout because the
+# migration only ever calls str(_id), so str("abc") == "abc" is fine.
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+_NOW = datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _row(session, table, **where):
+    """Fetch one row from table matching all where-clause column=value pairs."""
+    conds = " AND ".join(f'"{k}" = :{k}' for k in where)
+    return session.execute(text(f'SELECT * FROM "{table}" WHERE {conds}'), where).fetchone()
+
+
+def _count(session, table):
+    return session.execute(text(f'SELECT COUNT(*) FROM "{table}"')).scalar()
+
+
+def _scalar(session, sql, **params):
+    return session.execute(text(sql), params).scalar()
+
+
+# ── Users ─────────────────────────────────────────────────────────────────────
+
+def test_user_all_profile_fields_land_correctly(session):
+    """Verify specific field values, not just presence of a row.
+
+    Critique of a weaker version: if we only asserted _count(session, 'users') == 1
+    we would not catch a bug where firstName is stored in the wrong column, or
+    where interests is serialised as a Python repr instead of JSON.
+    """
+    mongo = FakeMongo(user=[{
+        "userId": 42,
+        "isMember": True,
+        "firstName": "Mikael",
+        "lastName": "Grön",
+        "slogan": "Hello world",
+        "age": 35,
+        "interests": ["Programmering och IT", "Böcker och litteratur"],
+        "social_vibes": ["creative"],
+        "settings": {
+            "show_location": "MEMBERS_ONLY",
+            "show_email": "NO_ONE",
+            "show_phone": "NO_ONE",
+            "show_profile": "MEMBERS_MUTUAL",
+            "show_interests": "EVERYONE",
+            "show_hometown": "NO_ONE",
+            "show_birthdate": "NO_ONE",
+            "show_gender": "NO_ONE",
+            "show_sexuality": "NO_ONE",
+            "show_relationship_style": "NO_ONE",
+            "show_relationship_status": "NO_ONE",
+            "show_social_vibes": "MEMBERS_ONLY",
+            "show_pronomen": "NO_ONE",
+            "show_attendance": "MEMBERS_MUTUAL",
+            "location_update_interval_seconds": 120,
+            "events_refresh_interval_seconds": 90,
+            "background_location_updates": True,
+        },
+        "location": {"latitude": 59.33, "longitude": 18.07, "accuracy": 5.0},
+        "contact_info": {"email": "m@test.com", "phone": "+46700000000"},
+        "hometown": "Stockholm",
+        "birthdate": "1989-01-01",
+        "gender": "male",
+    }])
+
+    migrate_users(session, mongo_source=mongo)
+
+    row = _row(session, "users", userId=42)
+    assert row is not None
+    assert row._mapping["firstName"] == "Mikael"
+    assert row._mapping["lastName"] == "Grön"
+    assert row._mapping["slogan"] == "Hello world"
+    assert row._mapping["age"] == 35
+    assert row._mapping["isMember"] == 1  # SQLite stores bool as int
+    assert row._mapping["show_location"] == "MEMBERS_ONLY"
+    assert row._mapping["show_interests"] == "EVERYONE"
+    assert row._mapping["location_latitude"] == 59.33
+    assert row._mapping["location_longitude"] == 18.07
+    assert row._mapping["contact_email"] == "m@test.com"
+    assert row._mapping["contact_phone"] == "+46700000000"
+    assert row._mapping["hometown"] == "Stockholm"
+    assert row._mapping["background_location_updates"] == 1
+    assert row._mapping["location_update_interval_seconds"] == 120
+
+    # Interests stored as JSON — verify the round-trip, not just that a string exists.
+    import json
+    interests = json.loads(row._mapping["interests"])
+    assert "Programmering och IT" in interests
+    assert len(interests) == 2
+
+    social_vibes = json.loads(row._mapping["social_vibes"])
+    assert social_vibes == ["creative"]
+
+
+def test_user_bool_show_email_true_coerced_to_members_only(session):
+    """Legacy Mongo docs stored show_email/show_phone as booleans.
+
+    _str(True) → "True" which is NOT a valid PrivacySetting and would silently
+    corrupt every user who had explicitly set show_email=True. _privacy() must
+    convert True → "MEMBERS_ONLY".
+
+    Critique: this test would be vacuous if it only checked that a row was
+    inserted. It must assert the exact string value in the column.
+    """
+    mongo = FakeMongo(user=[{
+        "userId": 1,
+        "isMember": False,
+        "settings": {
+            "show_email": True,   # old boolean format
+            "show_phone": False,  # old boolean format
+        },
+    }])
+
+    migrate_users(session, mongo_source=mongo)
+
+    row = _row(session, "users", userId=1)
+    assert row._mapping["show_email"] == "MEMBERS_ONLY", (
+        "show_email=True must become 'MEMBERS_ONLY', not 'True'"
+    )
+    assert row._mapping["show_phone"] == "NO_ONE", (
+        "show_phone=False must become 'NO_ONE', not 'False'"
+    )
+
+
+def test_user_missing_userId_is_skipped(session):
+    """A document with no userId must not create a row.
+
+    Critique: without this test a bug that silently inserts userId=None
+    (as NULL) would go undetected. We check count, not just absence of crash.
+    """
+    mongo = FakeMongo(user=[
+        {"isMember": False, "settings": {}},       # no userId
+        {"userId": 99, "isMember": True, "settings": {}},
+    ])
+
+    migrate_users(session, mongo_source=mongo)
+
+    assert _count(session, "users") == 1
+    assert _row(session, "users", userId=99) is not None
+
+
+def test_user_migration_is_idempotent(session):
+    """Running migrate_users twice must not create duplicate rows.
+
+    Critique of a weaker version: checking count == 1 after two runs does not
+    prove idempotency if the second run silently errors out. We also check that
+    the data is still readable (not rolled back) after both runs.
+    """
+    mongo = FakeMongo(user=[{"userId": 7, "isMember": True, "settings": {}}])
+
+    migrate_users(session, mongo_source=mongo)
+    migrate_users(session, mongo_source=mongo)
+
+    assert _count(session, "users") == 1
+    assert _row(session, "users", userId=7) is not None
+
+
+def test_user_second_run_updates_changed_data(session):
+    """ON CONFLICT DO UPDATE means re-running with changed Mongo data updates Postgres.
+
+    Critique: if we only tested idempotency with identical data we would miss
+    the case where a user's profile changed between migration attempts.
+    """
+    mongo_v1 = FakeMongo(user=[{"userId": 5, "isMember": False,
+                                 "slogan": "old", "settings": {}}])
+    mongo_v2 = FakeMongo(user=[{"userId": 5, "isMember": True,
+                                 "slogan": "new", "settings": {}}])
+
+    migrate_users(session, mongo_source=mongo_v1)
+    migrate_users(session, mongo_source=mongo_v2)
+
+    row = _row(session, "users", userId=5)
+    assert row._mapping["slogan"] == "new"
+    assert row._mapping["isMember"] == 1
+
+
+def test_user_null_optional_fields_stored_as_null(session):
+    """Fields absent from the Mongo doc must land as NULL, not empty string.
+
+    Critique: _str(None, "") returns "" and _str(None) also returns "". Using
+    _str for nullable fields would store "" instead of NULL, breaking IS NULL
+    queries and application-layer None checks.
+    """
+    mongo = FakeMongo(user=[{"userId": 3, "isMember": False, "settings": {}}])
+
+    migrate_users(session, mongo_source=mongo)
+
+    row = _row(session, "users", userId=3)
+    assert row._mapping["slogan"] is None
+    assert row._mapping["firstName"] is None
+    assert row._mapping["contact_email"] is None
+    assert row._mapping["location_latitude"] is None
+
+
+# ── Token storage ─────────────────────────────────────────────────────────────
+
+def test_token_storage_fields_land_correctly(session):
+    """Verify the token value and expiry time are not swapped or truncated."""
+    expires = datetime(2025, 12, 31, 23, 59, 0, tzinfo=timezone.utc)
+    mongo = FakeMongo(tokenstorage=[{
+        "userId": 10,
+        "externalAccessToken": "tok_abc123",
+        "createdAt": _NOW,
+        "expiresAt": expires,
+    }])
+
+    migrate_token_storage(session, mongo_source=mongo)
+
+    row = _row(session, "token_storage", userId=10)
+    assert row._mapping["externalAccessToken"] == "tok_abc123"
+    # SQLite stores datetimes as strings; check the token, not the timestamp format.
+
+
+def test_token_missing_userId_skipped(session):
+    mongo = FakeMongo(tokenstorage=[
+        {"externalAccessToken": "orphan"},          # no userId
+        {"userId": 20, "externalAccessToken": "good"},
+    ])
+
+    migrate_token_storage(session, mongo_source=mongo)
+
+    assert _count(session, "token_storage") == 1
+
+
+def test_token_storage_idempotent(session):
+    mongo = FakeMongo(tokenstorage=[{"userId": 15, "externalAccessToken": "t"}])
+    migrate_token_storage(session, mongo_source=mongo)
+    migrate_token_storage(session, mongo_source=mongo)
+    assert _count(session, "token_storage") == 1
+
+
+# ── User events ───────────────────────────────────────────────────────────────
+
+def test_event_all_child_rows_land(session):
+    """Each child collection (hosts, suggested_hosts, attendees, reports) is inserted.
+
+    Critique of a weaker version: checking only the parent event count would
+    miss bugs where child rows are silently dropped (wrong column name, failed
+    insert caught by a broad except, etc.).
+    """
+    mongo = FakeMongo(userevent=[{
+        "_id": "aaa111",
+        "userId": 1,
+        "name": "Meetup",
+        "start": _NOW,
+        "hosts": [{"userId": 2}, {"userId": 3}],
+        "suggested_hosts": [{"userId": 4}],
+        "attendees": [{"userId": 5}, {"userId": 6}],
+        "reports": [{"userId": 7, "text": "Inappropriate"}],
+    }])
+
+    migrate_user_events(session, mongo_source=mongo)
+
+    assert _count(session, "user_events") == 1
+    assert _count(session, "event_hosts") == 2
+    assert _count(session, "event_suggested_hosts") == 1
+    assert _count(session, "event_attendees") == 2
+    assert _count(session, "event_reports") == 1
+
+    report_text = _scalar(session, 'SELECT text FROM event_reports LIMIT 1')
+    assert report_text == "Inappropriate"
+
+
+def test_event_location_fields_land(session):
+    """Location is flattened from a nested Mongo object to individual columns."""
+    mongo = FakeMongo(userevent=[{
+        "_id": "loc1",
+        "userId": 1,
+        "name": "Outdoor",
+        "start": _NOW,
+        "location": {
+            "description": "The park",
+            "address": "Park Lane 1",
+            "marker": "🌳",
+            "latitude": 59.334591,
+            "longitude": 18.063240,
+        },
+    }])
+
+    migrate_user_events(session, mongo_source=mongo)
+
+    lat = _scalar(session, 'SELECT location_latitude FROM user_events LIMIT 1')
+    lon = _scalar(session, 'SELECT location_longitude FROM user_events LIMIT 1')
+    desc = _scalar(session, 'SELECT location_description FROM user_events LIMIT 1')
+    assert abs(lat - 59.334591) < 1e-6
+    assert abs(lon - 18.063240) < 1e-6
+    assert desc == "The park"
+
+
+def test_event_missing_userId_skipped(session):
+    mongo = FakeMongo(userevent=[
+        {"_id": "bad1", "name": "Ghost", "start": _NOW},  # no userId
+        {"_id": "ok1", "userId": 1, "name": "Real", "start": _NOW},
+    ])
+
+    migrate_user_events(session, mongo_source=mongo)
+
+    assert _count(session, "user_events") == 1
+
+
+def test_event_idempotent_no_duplicate_parent(session):
+    """The tracking table must prevent inserting the same event twice.
+
+    Critique: a naive ON CONFLICT on user_events would not help because
+    user_events has no natural unique key. This test would fail on the old
+    implementation (which used ON CONFLICT DO NOTHING against a non-existent
+    constraint — a silent no-op that then falls through to duplicate insertion).
+    """
+    mongo = FakeMongo(userevent=[{"_id": "e1", "userId": 1, "name": "Once", "start": _NOW}])
+
+    migrate_user_events(session, mongo_source=mongo)
+    migrate_user_events(session, mongo_source=mongo)
+
+    assert _count(session, "user_events") == 1, (
+        "Two runs of the migration must produce exactly one event row, "
+        "not two. The _mongo_migration_log tracking table must prevent re-insertion."
+    )
+
+
+def test_event_idempotent_no_duplicate_children(session):
+    """Child rows must not be doubled on re-run.
+
+    Critique: even if the parent is correctly deduplicated via the tracking table,
+    a bug could still re-insert children by fetching the existing pg_id and then
+    inserting child rows again. This test explicitly checks child counts.
+    """
+    mongo = FakeMongo(userevent=[{
+        "_id": "e2",
+        "userId": 1,
+        "name": "Party",
+        "start": _NOW,
+        "attendees": [{"userId": 2}, {"userId": 3}],
+        "hosts": [{"userId": 4}],
+    }])
+
+    migrate_user_events(session, mongo_source=mongo)
+    migrate_user_events(session, mongo_source=mongo)
+
+    assert _count(session, "event_attendees") == 2
+    assert _count(session, "event_hosts") == 1
+
+
+def test_event_tracking_table_is_populated(session):
+    """The _mongo_migration_log must record the mapping after migration.
+
+    Critique: this is an internal mechanism test. If the tracking table is
+    populated but the pg_id stored is wrong, the idempotency test would still
+    pass (skips re-insertion) but any downstream query using the wrong pg_id
+    would silently attach children to the wrong event. We verify pg_id is
+    consistent with the actual event row.
+    """
+    mongo = FakeMongo(userevent=[{
+        "_id": "track_me",
+        "userId": 1,
+        "name": "Tracked",
+        "start": _NOW,
+    }])
+
+    migrate_user_events(session, mongo_source=mongo)
+
+    logged_pg_id = _scalar(session,
+        "SELECT pg_id FROM _mongo_migration_log "
+        "WHERE collection = 'userevent' AND mongo_id = 'track_me'")
+    actual_pg_id = _scalar(session, 'SELECT id FROM user_events WHERE name = \'Tracked\'')
+
+    assert logged_pg_id is not None, "Tracking log must be populated"
+    assert logged_pg_id == actual_pg_id, (
+        "pg_id in tracking log must match the actual user_events.id"
+    )
+
+
+# ── External events ───────────────────────────────────────────────────────────
+
+def test_external_event_admins_and_categories_land(session):
+    """Admins and categories for an external event land in their child tables."""
+    mongo = FakeMongo(externaleventdetails=[{
+        "eventId": 100,
+        "startTime": "09:00", "endTime": "17:00",
+        "description": "Annual conf", "speaker": "Alice",
+        "location": "Stockholm", "isFree": False, "price": 500,
+        "isLimited": True, "stock": 50, "showBooked": True, "booked": 10,
+        "eventUrl": "https://example.com",
+        "admins": ["admin_a", "admin_b"],
+        "categories": [
+            {"code": "C1", "text": "Tech", "colorText": "#fff", "colorBackground": "#000"},
+            {"code": "C2", "text": "Science", "colorText": "#000", "colorBackground": "#eee"},
+        ],
+    }])
+
+    migrate_external_events(session, mongo_source=mongo)
+
+    assert _count(session, "external_event_admins") == 2
+    assert _count(session, "external_event_categories") == 2
+
+    cat_codes = [r[0] for r in session.execute(
+        text('SELECT code FROM external_event_categories ORDER BY code')).fetchall()]
+    assert cat_codes == ["C1", "C2"]
+
+
+def test_external_event_idempotent_replaces_children(session):
+    """Re-running must NOT double admins/categories.
+
+    The delete-then-reinsert strategy means re-running produces the same count,
+    not twice the count.
+
+    Critique: this tests the actual strategy (delete+reinsert), NOT a duplicate
+    check via a unique constraint (these tables have no such constraint). The
+    test would fail if the delete step were accidentally removed.
+    """
+    doc = {
+        "eventId": 200,
+        "startTime": "10:00", "endTime": "18:00",
+        "description": "d", "speaker": "s", "location": "l",
+        "isFree": True, "price": 0, "isLimited": False, "stock": 0,
+        "showBooked": False, "booked": 0, "eventUrl": "https://x.com",
+        "admins": ["adm1"],
+        "categories": [{"code": "X", "text": "X", "colorText": "#f", "colorBackground": "#0"}],
+    }
+    mongo = FakeMongo(externaleventdetails=[doc])
+
+    migrate_external_events(session, mongo_source=mongo)
+    migrate_external_events(session, mongo_source=mongo)
+
+    assert _count(session, "external_event_admins") == 1
+    assert _count(session, "external_event_categories") == 1
+
+
+# ── External root ─────────────────────────────────────────────────────────────
+
+def test_external_root_fields_and_dates_land(session):
+    """Scalar fields and the dates list all reach Postgres."""
+    mongo = FakeMongo(externalroot=[{
+        "version": 7,
+        "loginUrl": "https://login.example.com",
+        "restUrl": "https://api.example.com",
+        "siteUrl": "https://www.example.com",
+        "header1": "Mensa",
+        "header2": "Sverige",
+        "city": "Stockholm",
+        "streetAddress": "Kungsgatan 1",
+        "mapUrl": "https://maps.example.com",
+        "dates": ["2024-09-01", "2024-09-15", "2024-10-01"],
+    }])
+
+    migrate_external_root(session, mongo_source=mongo)
+
+    version = _scalar(session, 'SELECT version FROM external_root WHERE id = 1')
+    assert version == 7
+
+    city = _scalar(session, 'SELECT city FROM external_root WHERE id = 1')
+    assert city == "Stockholm"
+
+    date_count = _count(session, "external_root_dates")
+    assert date_count == 3
+
+    dates = sorted(r[0] for r in session.execute(
+        text('SELECT date_value FROM external_root_dates')).fetchall())
+    assert dates == ["2024-09-01", "2024-09-15", "2024-10-01"]
+
+
+def test_external_root_idempotent_replaces_dates(session):
+    """Re-running replaces dates, not appends them."""
+    doc = {
+        "version": 1, "loginUrl": "u", "restUrl": "u", "siteUrl": "u",
+        "header1": "h", "header2": "h", "city": "c", "streetAddress": "s",
+        "mapUrl": "m", "dates": ["2024-01-01", "2024-02-01"],
+    }
+    mongo = FakeMongo(externalroot=[doc])
+
+    migrate_external_root(session, mongo_source=mongo)
+    migrate_external_root(session, mongo_source=mongo)
+
+    assert _count(session, "external_root_dates") == 2
+
+
+def test_external_root_empty_collection_is_noop(session):
+    """An empty externalroot collection must not error or insert garbage."""
+    mongo = FakeMongo(externalroot=[])
+
+    total, migrated = migrate_external_root(session, mongo_source=mongo)
+
+    assert total == 0
+    assert migrated == 0
+    assert _count(session, "external_root") == 0
+
+
+# ── External event bookings ───────────────────────────────────────────────────
+
+def test_booking_idempotent_no_duplicate(session):
+    """The same booking inserted twice must produce exactly one row.
+
+    Critique: ON CONFLICT ("userId", "eventId") DO NOTHING must match the
+    actual unique constraint columns. If the column names are wrong (e.g. "eventId"
+    vs "eid"), this would throw instead of silently deduplicating. A passing test
+    confirms the column names in the INSERT match the constraint.
+    """
+    mongo = FakeMongo(externaleventbooking=[{"userId": 1, "eventId": 100}])
+
+    migrate_external_event_bookings(session, mongo_source=mongo)
+    migrate_external_event_bookings(session, mongo_source=mongo)
+
+    assert _count(session, "external_event_bookings") == 1
+
+
+def test_booking_missing_fields_skipped(session):
+    mongo = FakeMongo(externaleventbooking=[
+        {"userId": 1},           # no eventId
+        {"eventId": 100},         # no userId
+        {"userId": 2, "eventId": 200},
+    ])
+
+    migrate_external_event_bookings(session, mongo_source=mongo)
+
+    assert _count(session, "external_event_bookings") == 1
+
+
+# ── Validation ────────────────────────────────────────────────────────────────
+
+def test_validate_ok_when_counts_match(session):
+    """Validation returns True when Mongo and Postgres counts agree."""
+    mongo = FakeMongo(
+        user=[{"userId": 1, "isMember": False, "settings": {}}],
+        tokenstorage=[],
+        userevent=[],
+        externaleventdetails=[],
+        externaleventbooking=[],
+    )
+    migrate_users(session, mongo_source=mongo)
+
+    result = validate(session, mongo_source=mongo)
+    assert result is True
+
+
+def test_validate_detects_postgres_has_fewer_rows(session):
+    """Validation returns False when Postgres has fewer rows than Mongo.
+
+    This is the standard migration-incomplete case.
+    """
+    mongo = FakeMongo(
+        user=[
+            {"userId": 1, "isMember": False, "settings": {}},
+            {"userId": 2, "isMember": False, "settings": {}},
+        ],
+        tokenstorage=[], userevent=[], externaleventdetails=[], externaleventbooking=[],
+    )
+    # Migrate only one of the two users manually to force a mismatch.
+    session.execute(text("""
+        INSERT INTO users ("userId", "isMember",
+            show_location, show_profile, show_email, show_phone,
+            show_interests, show_hometown, show_birthdate, show_gender,
+            show_sexuality, show_relationship_style, show_relationship_status,
+            show_social_vibes, show_pronomen, show_attendance,
+            location_update_interval_seconds, events_refresh_interval_seconds,
+            background_location_updates, created_at, updated_at)
+        VALUES (1, 0, 'NO_ONE','MEMBERS_MUTUAL','NO_ONE','NO_ONE',
+                'MEMBERS_MUTUAL','MEMBERS_MUTUAL','MEMBERS_MUTUAL','NO_ONE',
+                'NO_ONE','NO_ONE','NO_ONE','MEMBERS_MUTUAL','NO_ONE','MEMBERS_MUTUAL',
+                60, 60, 0, '2024-01-01', '2024-01-01')
+    """))
+    session.commit()
+
+    result = validate(session, mongo_source=mongo)
+    assert result is False
+
+
+def test_validate_detects_postgres_has_more_rows(session):
+    """Validation returns False when Postgres has MORE rows than Mongo.
+
+    This is the double-insertion bug case. Old code used >= instead of ==,
+    which would silently pass this scenario and hide the bug.
+
+    Critique: this is the most important validation test. The == vs >= choice
+    exists precisely to catch this. Without this test, reverting to >= would
+    go unnoticed.
+    """
+
+    # Simulate two rows in Postgres for one row in Mongo.
+    for uid in (1, 2):
+        session.execute(text("""
+            INSERT INTO users ("userId", "isMember",
+                show_location, show_profile, show_email, show_phone,
+                show_interests, show_hometown, show_birthdate, show_gender,
+                show_sexuality, show_relationship_style, show_relationship_status,
+                show_social_vibes, show_pronomen, show_attendance,
+                location_update_interval_seconds, events_refresh_interval_seconds,
+                background_location_updates, created_at, updated_at)
+            VALUES (:uid, 0, 'NO_ONE','MEMBERS_MUTUAL','NO_ONE','NO_ONE',
+                    'MEMBERS_MUTUAL','MEMBERS_MUTUAL','MEMBERS_MUTUAL','NO_ONE',
+                    'NO_ONE','NO_ONE','NO_ONE','MEMBERS_MUTUAL','NO_ONE','MEMBERS_MUTUAL',
+                    60, 60, 0, '2024-01-01', '2024-01-01')
+        """), {"uid": uid})
+    session.commit()
+
+    # Mongo has only ONE user document.
+    mongo = FakeMongo(
+        user=[{"userId": 1, "isMember": False, "settings": {}}],
+        tokenstorage=[], userevent=[], externaleventdetails=[], externaleventbooking=[],
+    )
+
+    result = validate(session, mongo_source=mongo)
+    assert result is False, (
+        "Validation must return False when Postgres has MORE rows than Mongo. "
+        "This catches double-insertion bugs that >= would silently accept."
+    )

--- a/backend/tests/test_user_events.py
+++ b/backend/tests/test_user_events.py
@@ -305,3 +305,134 @@ def test_event_with_location():
     assert event.location is not None
     assert event.location.description == "Conference room"
     assert event.location.latitude == 59.33
+
+
+# ── Concurrency: unique constraints + SELECT FOR UPDATE (swagapp-l68d1) ───────
+
+def test_add_same_attendee_twice_is_idempotent_and_no_duplicate_row():
+    """UniqueConstraint prevents duplicate attendee rows even on rapid re-add."""
+    _seed_users()
+    event_id = create_user_event(_make_event())
+
+    r1 = add_attendee_to_user_event(str(event_id), 200)
+    r2 = add_attendee_to_user_event(str(event_id), 200)
+
+    assert r1 is True
+    assert r2 is True  # idempotent
+    event = get_unsafe_user_event(str(event_id))
+    assert len(event.attendees) == 1
+
+
+def test_capacity_enforced_under_rapid_sequential_calls():
+    """Two different users adding to a 1-slot event: exactly one succeeds."""
+    _seed_users()
+    event_id = create_user_event(_make_event(maxAttendees=1))
+
+    results = [
+        add_attendee_to_user_event(str(event_id), 200),
+        add_attendee_to_user_event(str(event_id), 300),
+    ]
+
+    event = get_unsafe_user_event(str(event_id))
+    assert len(event.attendees) == 1
+    assert results.count(True) == 1
+    assert results.count(False) == 1
+
+
+def test_unique_constraint_rejects_duplicate_attendee_at_db_level():
+    """The UniqueConstraint on event_attendees catches races that bypass Python checks.
+
+    Simulates what would happen if two concurrent requests both passed the
+    duplicate check (e.g. pre-lock race): the second DB insert must be rejected.
+    add_attendee_to_user_event handles the IntegrityError gracefully (returns False).
+    """
+    from sqlalchemy.exc import IntegrityError
+    from v1.db.database import get_session
+    from v1.db.tables import EventAttendeeTable
+
+    _seed_users()
+    event_id = create_user_event(_make_event())
+
+    # First insert succeeds
+    with get_session() as session:
+        session.add(EventAttendeeTable(event_id=event_id, userId=200))
+        session.commit()
+
+    # Second insert of the same (event_id, userId) must raise IntegrityError
+    raised = False
+    try:
+        with get_session() as session:
+            session.add(EventAttendeeTable(event_id=event_id, userId=200))
+            session.commit()
+    except IntegrityError:
+        raised = True
+
+    assert raised, "UniqueConstraint must reject duplicate (event_id, userId)"
+
+    event = get_unsafe_user_event(str(event_id))
+    assert len(event.attendees) == 1
+
+
+def test_add_host_twice_is_idempotent():
+    """UniqueConstraint on event_hosts prevents duplicate host rows."""
+    _seed_users()
+    event_id = create_user_event(_make_event())
+
+    add_user_as_host_to_user_event(str(event_id), 200)
+    add_user_as_host_to_user_event(str(event_id), 200)
+
+    event = get_unsafe_user_event(str(event_id))
+    assert len(event.hosts) == 1
+
+
+# ── TOCTOU race fix: single-session update (swagapp-ll0s9) ────────────────────
+
+def test_update_preserves_reports_from_sanitized_event():
+    """update_user_event with a sanitized (no-report) event must not wipe reports.
+
+    This is the key invariant the single-session TOCTOU fix ensures:
+    reports are restored from the locked DB row, not from the caller's event.
+    """
+    _seed_users()
+    event_id = create_user_event(_make_event(reports=[{"userId": 200, "text": "Reported!"}]))
+
+    # Simulate what the API layer does: fetch safe (reports stripped), then update
+    safe = get_safe_user_event(str(event_id))
+    assert len(safe.reports) == 0  # reports hidden from safe view
+
+    # Construct a UserEvent from the safe view (reports = [])
+    safe_as_user_event = UserEvent(**{
+        **safe.model_dump(),
+        "reports": [],  # caller doesn't know about reports
+    })
+
+    result = update_user_event(str(event_id), safe_as_user_event)
+    assert result is True
+
+    updated = get_unsafe_user_event(str(event_id))
+    assert len(updated.reports) == 1, "Report must survive update with sanitized event"
+    assert updated.reports[0].text == "Reported!"
+
+
+def test_update_applies_all_fields_in_single_session():
+    """update_user_event correctly persists field changes without a session gap."""
+    _seed_users()
+    event_id = create_user_event(_make_event(name="Original", maxAttendees=5))
+
+    event = get_unsafe_user_event(str(event_id))
+    event.name = "Renamed"
+    event.maxAttendees = 10
+
+    assert update_user_event(str(event_id), event) is True
+
+    updated = get_unsafe_user_event(str(event_id))
+    assert updated.name == "Renamed"
+    assert updated.maxAttendees == 10
+
+
+def test_update_nonexistent_event_returns_false():
+    """update_user_event returns False when the event does not exist."""
+    _seed_users()
+    dummy = _make_event()
+    dummy.id = None
+    assert update_user_event("99999", dummy) is False

--- a/backend/tests/test_user_events.py
+++ b/backend/tests/test_user_events.py
@@ -1,0 +1,307 @@
+"""Tests for user event DB operations."""
+
+from datetime import datetime, timedelta
+from v1.db.users import create_user
+from v1.user_events.user_events_model import UserEvent
+from v1.user_events.user_events_db import (
+    create_user_event,
+    get_unsafe_user_event,
+    get_safe_user_event,
+    update_user_event,
+    delete_user_event,
+    get_unsafe_future_user_events,
+    get_safe_future_user_events,
+    get_unsafe_user_events_user_owns,
+    get_unsafe_user_events_user_is_hosting,
+    get_unsafe_user_events_user_is_attending,
+    add_attendee_to_user_event,
+    remove_attendee_from_user_event,
+    add_user_as_host_to_user_event,
+    remove_user_from_hosts_of_user_event,
+    get_unsafe_user_events_user_is_invited_to_host,
+    remove_user_host_invitation_from_user_event,
+    add_or_update_report_on_user_event,
+    remove_report_from_user_event,
+)
+
+
+def _seed_users():
+    """Create test users needed for extend_user_events lookups."""
+    create_user({"memberId": 100, "type": "M", "firstName": "Alice", "lastName": "A", "email": "a@test.com"})
+    create_user({"memberId": 200, "type": "M", "firstName": "Bob", "lastName": "B", "email": "b@test.com"})
+    create_user({"memberId": 300, "type": "M", "firstName": "Charlie", "lastName": "C", "email": "c@test.com"})
+
+
+def _make_event(**overrides) -> UserEvent:
+    now = datetime.now()
+    base = dict(
+        userId=100,
+        name="Test Event",
+        start=now + timedelta(hours=1),
+        end=now + timedelta(hours=3),
+        description="A test event",
+        hosts=[],
+        suggested_hosts=[],
+        attendees=[],
+        reports=[],
+    )
+    base.update(overrides)
+    return UserEvent(**base)
+
+
+# ── CRUD ──────────────────────────────────────────────────────────────────────
+
+def test_create_and_get_event():
+    _seed_users()
+    event = _make_event()
+    event_id = create_user_event(event)
+    assert event_id is not None
+
+    fetched = get_unsafe_user_event(str(event_id))
+    assert fetched is not None
+    assert fetched.name == "Test Event"
+    assert fetched.userId == 100
+
+
+def test_get_nonexistent_event():
+    assert get_unsafe_user_event("99999") is None
+
+
+def test_get_safe_event_hides_reports():
+    _seed_users()
+    event = _make_event(reports=[{"userId": 200, "text": "Bad event"}])
+    event_id = create_user_event(event)
+
+    unsafe = get_unsafe_user_event(str(event_id))
+    assert len(unsafe.reports) == 1
+
+    safe = get_safe_user_event(str(event_id))
+    assert safe is not None
+    assert len(safe.reports) == 0
+    assert safe.ownerName == "Alice A"
+
+
+def test_update_event():
+    _seed_users()
+    event_id = create_user_event(_make_event())
+    event = get_unsafe_user_event(str(event_id))
+    event.name = "Updated Event"
+    assert update_user_event(str(event_id), event) is True
+
+    fetched = get_unsafe_user_event(str(event_id))
+    assert fetched.name == "Updated Event"
+
+
+def test_delete_event():
+    _seed_users()
+    event_id = create_user_event(_make_event())
+    assert delete_user_event(str(event_id)) is True
+    assert get_unsafe_user_event(str(event_id)) is None
+
+
+def test_delete_nonexistent_event():
+    assert delete_user_event("99999") is False
+
+
+# ── Future events ─────────────────────────────────────────────────────────────
+
+def test_get_future_events():
+    _seed_users()
+    now = datetime.now()
+
+    # Future event (should appear)
+    create_user_event(_make_event(
+        name="Future",
+        start=now + timedelta(hours=2),
+        end=now + timedelta(hours=4),
+    ))
+    # Past event (should not appear)
+    create_user_event(_make_event(
+        name="Past",
+        start=now - timedelta(hours=10),
+        end=now - timedelta(hours=8),
+    ))
+
+    events = get_unsafe_future_user_events()
+    assert len(events) == 1
+    assert events[0].name == "Future"
+
+
+def test_get_future_events_no_end():
+    """Events with no end time should appear if start is recent."""
+    _seed_users()
+    now = datetime.now()
+    create_user_event(_make_event(
+        name="No End",
+        start=now - timedelta(minutes=30),
+        end=None,
+    ))
+    events = get_unsafe_future_user_events()
+    assert len(events) == 1
+    assert events[0].name == "No End"
+
+
+def test_safe_future_events_include_names():
+    _seed_users()
+    create_user_event(_make_event())
+    events = get_safe_future_user_events()
+    assert len(events) == 1
+    assert events[0].ownerName == "Alice A"
+
+
+# ── Ownership / hosting / attending queries ───────────────────────────────────
+
+def test_events_user_owns():
+    _seed_users()
+    create_user_event(_make_event(userId=100, name="Owned"))
+    create_user_event(_make_event(userId=200, name="Other"))
+
+    owned = get_unsafe_user_events_user_owns(100)
+    assert len(owned) == 1
+    assert owned[0].name == "Owned"
+
+
+def test_events_user_is_hosting():
+    _seed_users()
+    event_id = create_user_event(_make_event(hosts=[{"userId": 200}]))
+
+    hosting = get_unsafe_user_events_user_is_hosting(200)
+    assert len(hosting) == 1
+
+    not_hosting = get_unsafe_user_events_user_is_hosting(300)
+    assert len(not_hosting) == 0
+
+
+def test_events_user_is_attending():
+    _seed_users()
+    create_user_event(_make_event(attendees=[{"userId": 200}]))
+
+    attending = get_unsafe_user_events_user_is_attending(200)
+    assert len(attending) == 1
+
+    not_attending = get_unsafe_user_events_user_is_attending(300)
+    assert len(not_attending) == 0
+
+
+# ── Attendee management ──────────────────────────────────────────────────────
+
+def test_add_and_remove_attendee():
+    _seed_users()
+    event_id = create_user_event(_make_event())
+
+    assert add_attendee_to_user_event(str(event_id), 200) is True
+    event = get_unsafe_user_event(str(event_id))
+    assert len(event.attendees) == 1
+    assert event.attendees[0].userId == 200
+
+    # Adding same user again should be idempotent
+    assert add_attendee_to_user_event(str(event_id), 200) is True
+    event = get_unsafe_user_event(str(event_id))
+    assert len(event.attendees) == 1
+
+    assert remove_attendee_from_user_event(str(event_id), 200) is True
+    event = get_unsafe_user_event(str(event_id))
+    assert len(event.attendees) == 0
+
+
+def test_max_attendees_enforced():
+    _seed_users()
+    event_id = create_user_event(_make_event(maxAttendees=1))
+
+    assert add_attendee_to_user_event(str(event_id), 200) is True
+    assert add_attendee_to_user_event(str(event_id), 300) is False
+
+    event = get_unsafe_user_event(str(event_id))
+    assert len(event.attendees) == 1
+
+
+# ── Host management ──────────────────────────────────────────────────────────
+
+def test_add_host_from_suggested():
+    _seed_users()
+    event_id = create_user_event(_make_event(suggested_hosts=[{"userId": 200}]))
+
+    event = get_unsafe_user_event(str(event_id))
+    assert len(event.suggested_hosts) == 1
+    assert len(event.hosts) == 0
+
+    assert add_user_as_host_to_user_event(str(event_id), 200) is True
+
+    event = get_unsafe_user_event(str(event_id))
+    assert len(event.hosts) == 1
+    assert len(event.suggested_hosts) == 0
+
+
+def test_remove_host():
+    _seed_users()
+    event_id = create_user_event(_make_event(hosts=[{"userId": 200}]))
+
+    assert remove_user_from_hosts_of_user_event(str(event_id), 200) is True
+    event = get_unsafe_user_event(str(event_id))
+    assert len(event.hosts) == 0
+
+
+def test_invited_to_host_query():
+    _seed_users()
+    create_user_event(_make_event(suggested_hosts=[{"userId": 200}]))
+
+    invited = get_unsafe_user_events_user_is_invited_to_host(200)
+    assert len(invited) == 1
+
+    not_invited = get_unsafe_user_events_user_is_invited_to_host(300)
+    assert len(not_invited) == 0
+
+
+def test_remove_host_invitation():
+    _seed_users()
+    event_id = create_user_event(_make_event(suggested_hosts=[{"userId": 200}]))
+
+    assert remove_user_host_invitation_from_user_event(str(event_id), 200) is True
+    event = get_unsafe_user_event(str(event_id))
+    assert len(event.suggested_hosts) == 0
+
+
+# ── Reports ───────────────────────────────────────────────────────────────────
+
+def test_add_and_update_report():
+    _seed_users()
+    event_id = create_user_event(_make_event())
+
+    assert add_or_update_report_on_user_event(str(event_id), 200, "Bad") is True
+    event = get_unsafe_user_event(str(event_id))
+    assert len(event.reports) == 1
+    assert event.reports[0].text == "Bad"
+
+    # Update same user's report
+    assert add_or_update_report_on_user_event(str(event_id), 200, "Very bad") is True
+    event = get_unsafe_user_event(str(event_id))
+    assert len(event.reports) == 1
+    assert event.reports[0].text == "Very bad"
+
+
+def test_remove_report():
+    _seed_users()
+    event_id = create_user_event(_make_event())
+    add_or_update_report_on_user_event(str(event_id), 200, "Bad")
+
+    assert remove_report_from_user_event(str(event_id), 200) is True
+    event = get_unsafe_user_event(str(event_id))
+    assert len(event.reports) == 0
+
+
+# ── Event with location ──────────────────────────────────────────────────────
+
+def test_event_with_location():
+    _seed_users()
+    event_id = create_user_event(_make_event(location={
+        "description": "Conference room",
+        "address": "123 Main St",
+        "marker": "📍",
+        "latitude": 59.33,
+        "longitude": 18.07,
+    }))
+
+    event = get_unsafe_user_event(str(event_id))
+    assert event.location is not None
+    assert event.location.description == "Conference room"
+    assert event.location.latitude == 59.33

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -1,6 +1,9 @@
 """Tests for user DB operations."""
 
-from v1.db.users import create_user, get_user, update_user, get_users, get_users_showing_location
+from v1.db.users import (
+    create_user, get_user, update_user, get_users,
+    get_users_showing_location, update_user_from_authresponse,
+)
 
 
 def _make_auth_response(**overrides):
@@ -35,21 +38,19 @@ def test_get_nonexistent_user():
 
 def test_update_user_profile():
     create_user(_make_auth_response())
-    fetched = get_user(1001)
-    assert fetched["slogan"] is None
+    assert get_user(1001)["slogan"] is None
 
     update_user(1001, {"slogan": "Hello world"})
-    fetched = get_user(1001)
-    assert fetched["slogan"] == "Hello world"
+    assert get_user(1001)["slogan"] == "Hello world"
 
 
-def test_update_user_settings():
+def test_update_user_settings_privacy():
     create_user(_make_auth_response())
     update_user(1001, {
         "settings": {
             "show_location": "EVERYONE",
-            "show_email": True,
-            "show_phone": False,
+            "show_email": "MEMBERS_ONLY",
+            "show_phone": "NO_ONE",
             "location_update_interval_seconds": 30,
             "events_refresh_interval_seconds": 30,
             "background_location_updates": True,
@@ -57,8 +58,17 @@ def test_update_user_settings():
     })
     fetched = get_user(1001)
     assert fetched["settings"]["show_location"] == "EVERYONE"
-    assert fetched["settings"]["show_email"] is True
+    assert fetched["settings"]["show_email"] == "MEMBERS_ONLY"
+    assert fetched["settings"]["show_phone"] == "NO_ONE"
     assert fetched["settings"]["location_update_interval_seconds"] == 30
+
+
+def test_privacy_setting_round_trip_all_values():
+    """All PrivacySetting values survive a write/read round-trip."""
+    create_user(_make_auth_response())
+    for value in ("NO_ONE", "MEMBERS_ONLY", "MEMBERS_MUTUAL", "EVERYONE_MUTUAL", "EVERYONE"):
+        update_user(1001, {"settings": {"show_email": value}})
+        assert get_user(1001)["settings"]["show_email"] == value
 
 
 def test_update_user_location():
@@ -75,10 +85,8 @@ def test_update_user_location():
     assert fetched["location"] is not None
     assert fetched["location"]["latitude"] == 59.33
 
-    # Clear location
     update_user(1001, {"location": None})
-    fetched = get_user(1001)
-    assert fetched["location"] is None
+    assert get_user(1001)["location"] is None
 
 
 def test_update_user_contact_info():
@@ -91,27 +99,74 @@ def test_update_user_contact_info():
     assert fetched["contact_info"]["phone"] == "+46701234567"
 
 
+def test_update_user_profile_fields():
+    """interests, hometown, birthdate and other profile fields persist."""
+    create_user(_make_auth_response())
+    update_user(1001, {
+        "interests": ["Böcker och litteratur"],
+        "hometown": "Stockholm",
+        "birthdate": "1989-11-15",
+        "gender": "male",
+        "sexuality": "straight",
+        "relationship_style": "monogamous",
+        "relationship_status": "has_partner",
+        "social_vibes": ["social"],
+        "pronomen": "hen",
+    })
+    fetched = get_user(1001)
+    assert fetched["hometown"] == "Stockholm"
+    assert fetched["birthdate"] == "1989-11-15"
+    assert fetched["gender"] == "male"
+    assert fetched["pronomen"] == "hen"
+    assert fetched["interests"] == ["Böcker och litteratur"]
+    assert fetched["social_vibes"] == ["social"]
+
+
 def test_get_users_all():
     create_user(_make_auth_response(memberId=1001))
     create_user(_make_auth_response(memberId=1002, firstName="Other"))
-    users = get_users()
-    assert len(users) == 2
+    assert len(get_users()) == 2
 
 
 def test_get_users_showing_location():
     create_user(_make_auth_response(memberId=1001))
     create_user(_make_auth_response(memberId=1002))
 
-    # Default is NO_ONE, so no one should show
     assert len(get_users_showing_location()) == 0
 
-    # Update one to share location
     update_user(1001, {"settings": {
         "show_location": "EVERYONE",
-        "show_email": False,
-        "show_phone": False,
+        "show_email": "NO_ONE",
+        "show_phone": "NO_ONE",
         "location_update_interval_seconds": 60,
         "events_refresh_interval_seconds": 60,
         "background_location_updates": False,
     }})
     assert len(get_users_showing_location()) == 1
+
+
+def test_update_user_from_authresponse_updates_fields():
+    create_user(_make_auth_response())
+    update_user_from_authresponse(1001, {
+        "firstName": "Updated",
+        "lastName": "Name",
+        "email": "updated@example.com",
+        "type": "M",
+    })
+    fetched = get_user(1001)
+    assert fetched["firstName"] == "Updated"
+    assert fetched["isMember"] is True
+
+
+def test_update_user_from_authresponse_absent_type_does_not_demote():
+    """Missing 'type' key must not change isMember."""
+    create_user(_make_auth_response())
+    assert get_user(1001)["isMember"] is True
+
+    update_user_from_authresponse(1001, {"firstName": "NoType"})
+    assert get_user(1001)["isMember"] is True
+
+
+def test_update_user_from_authresponse_nonexistent_user():
+    # Should not raise
+    update_user_from_authresponse(9999, {"firstName": "Ghost", "type": "M"})

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -1,0 +1,117 @@
+"""Tests for user DB operations."""
+
+from v1.db.users import create_user, get_user, update_user, get_users, get_users_showing_location
+
+
+def _make_auth_response(**overrides):
+    base = {
+        "memberId": 1001,
+        "type": "M",
+        "firstName": "Test",
+        "lastName": "User",
+        "email": "test@example.com",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_create_and_get_user():
+    auth = _make_auth_response()
+    result = create_user(auth)
+    assert result is not None
+    assert result["userId"] == 1001
+    assert result["isMember"] is True
+
+    fetched = get_user(1001)
+    assert fetched is not None
+    assert fetched["userId"] == 1001
+    assert fetched["firstName"] == "Test"
+    assert fetched["lastName"] == "User"
+
+
+def test_get_nonexistent_user():
+    assert get_user(9999) is None
+
+
+def test_update_user_profile():
+    create_user(_make_auth_response())
+    fetched = get_user(1001)
+    assert fetched["slogan"] is None
+
+    update_user(1001, {"slogan": "Hello world"})
+    fetched = get_user(1001)
+    assert fetched["slogan"] == "Hello world"
+
+
+def test_update_user_settings():
+    create_user(_make_auth_response())
+    update_user(1001, {
+        "settings": {
+            "show_location": "EVERYONE",
+            "show_email": True,
+            "show_phone": False,
+            "location_update_interval_seconds": 30,
+            "events_refresh_interval_seconds": 30,
+            "background_location_updates": True,
+        }
+    })
+    fetched = get_user(1001)
+    assert fetched["settings"]["show_location"] == "EVERYONE"
+    assert fetched["settings"]["show_email"] is True
+    assert fetched["settings"]["location_update_interval_seconds"] == 30
+
+
+def test_update_user_location():
+    create_user(_make_auth_response())
+    update_user(1001, {
+        "location": {
+            "latitude": 59.33,
+            "longitude": 18.07,
+            "timestamp": None,
+            "accuracy": 5.0,
+        }
+    })
+    fetched = get_user(1001)
+    assert fetched["location"] is not None
+    assert fetched["location"]["latitude"] == 59.33
+
+    # Clear location
+    update_user(1001, {"location": None})
+    fetched = get_user(1001)
+    assert fetched["location"] is None
+
+
+def test_update_user_contact_info():
+    create_user(_make_auth_response())
+    update_user(1001, {
+        "contact_info": {"email": "new@example.com", "phone": "+46701234567"}
+    })
+    fetched = get_user(1001)
+    assert fetched["contact_info"]["email"] == "new@example.com"
+    assert fetched["contact_info"]["phone"] == "+46701234567"
+
+
+def test_get_users_all():
+    create_user(_make_auth_response(memberId=1001))
+    create_user(_make_auth_response(memberId=1002, firstName="Other"))
+    users = get_users()
+    assert len(users) == 2
+
+
+def test_get_users_showing_location():
+    create_user(_make_auth_response(memberId=1001))
+    create_user(_make_auth_response(memberId=1002))
+
+    # Default is NO_ONE, so no one should show
+    assert len(get_users_showing_location()) == 0
+
+    # Update one to share location
+    update_user(1001, {"settings": {
+        "show_location": "EVERYONE",
+        "show_email": False,
+        "show_phone": False,
+        "location_update_interval_seconds": 60,
+        "events_refresh_interval_seconds": 60,
+        "background_location_updates": False,
+    }})
+    assert len(get_users_showing_location()) == 1

--- a/backend/v1/db/database.py
+++ b/backend/v1/db/database.py
@@ -1,0 +1,62 @@
+import os
+import logging
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, DeclarativeBase
+
+logging.basicConfig(level=logging.INFO)
+
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://swag:swag@postgres:5432/swag")
+
+engine = create_engine(DATABASE_URL, echo=False)
+SessionLocal = sessionmaker(bind=engine)
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+def get_db():
+    """Yield a database session, closing it when done."""
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def initialize_db():
+    """Create all tables and seed review users."""
+    from v1.db.tables import UserTable  # noqa: F401 — ensure all models are imported
+    from v1.db.tables import TokenStorageTable  # noqa: F401
+    from v1.db.tables import UserEventTable, EventHostTable, EventSuggestedHostTable, EventAttendeeTable, EventReportTable  # noqa: F401
+    from v1.db.tables import ExternalEventDetailsTable, ExternalEventCategoryTable, ExternalEventAdminTable  # noqa: F401
+    from v1.db.tables import ExternalRootTable, ExternalRootDateTable  # noqa: F401
+
+    Base.metadata.create_all(bind=engine)
+    logging.info("All database tables created.")
+
+    _seed_review_users()
+
+
+def _seed_review_users():
+    """Ensure review users exist in the database."""
+    from v1.db.review_users import review_users
+    from v1.db.tables import UserTable
+
+    if not review_users:
+        logging.info("No review users configured.")
+        return
+
+    logging.info("Ensuring review users exist.")
+    with SessionLocal() as session:
+        for review_user in review_users:
+            existing = session.query(UserTable).filter_by(userId=review_user.userId).first()
+            user_data = review_user.model_dump()
+            if existing:
+                for key, value in user_data.items():
+                    if hasattr(existing, key):
+                        setattr(existing, key, value)
+            else:
+                row = UserTable.from_pydantic(review_user)
+                session.add(row)
+        session.commit()

--- a/backend/v1/db/database.py
+++ b/backend/v1/db/database.py
@@ -10,7 +10,12 @@ logging.basicConfig(level=logging.INFO)
 
 DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://swag:swag@postgres:5432/swag")
 
-engine = create_engine(DATABASE_URL, echo=False)
+engine = create_engine(
+    DATABASE_URL,
+    echo=False,
+    pool_pre_ping=True,
+    pool_recycle=300,
+)
 SessionLocal = sessionmaker(bind=engine)
 
 
@@ -61,13 +66,24 @@ def run_alembic_migrations():
         has_app_tables = bool(existing_tables - {"alembic_version"})
 
     if has_app_tables and not has_alembic_version:
-        # Pre-Alembic database — stamp as already at head so Alembic
-        # knows the initial migration has already been applied.
-        logging.info(
-            "Detected pre-Alembic database (tables exist, no alembic_version). "
-            "Stamping at head."
-        )
-        command.stamp(alembic_cfg, "head")
+        # Only stamp when ALL expected tables are present. A partially-migrated
+        # DB (crash mid-upgrade before alembic_version was written) should NOT
+        # be stamped — let upgrade run and fail loudly so the gap is visible.
+        from v1.db.tables import Base as _Base
+        expected = set(_Base.metadata.tables.keys())
+        missing = expected - existing_tables
+        if missing:
+            logging.warning(
+                "Pre-Alembic DB detected but %d expected tables are missing (%s). "
+                "Will let alembic upgrade run rather than stamp.",
+                len(missing), ", ".join(sorted(missing)),
+            )
+        else:
+            logging.info(
+                "Detected pre-Alembic database with all %d tables present. "
+                "Stamping at head.", len(expected),
+            )
+            command.stamp(alembic_cfg, "head")
 
     command.upgrade(alembic_cfg, "head")
     logging.info("Alembic migrations applied (or already up to date).")

--- a/backend/v1/db/database.py
+++ b/backend/v1/db/database.py
@@ -1,5 +1,7 @@
 import os
+import time
 import logging
+from contextlib import contextmanager
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, DeclarativeBase
 
@@ -15,32 +17,48 @@ class Base(DeclarativeBase):
     pass
 
 
+@contextmanager
 def get_session():
-    """Return a new database session. Always call this instead of SessionLocal() directly."""
-    return SessionLocal()
+    """Context manager yielding a session with auto-rollback on exception."""
+    session = SessionLocal()
+    try:
+        yield session
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
 
 
 def get_db():
     """Yield a database session, closing it when done."""
-    db = get_session()
-    try:
+    with get_session() as db:
         yield db
-    finally:
-        db.close()
 
 
-def initialize_db():
-    """Create all tables and seed review users."""
-    from v1.db.tables import UserTable  # noqa: F401 — ensure all models are imported
+def initialize_db(max_retries: int = 5, retry_delay: float = 2.0):
+    """Create all tables, retrying on connection failure."""
+    from v1.db.tables import UserTable  # noqa: F401
     from v1.db.tables import TokenStorageTable  # noqa: F401
     from v1.db.tables import UserEventTable, EventHostTable, EventSuggestedHostTable, EventAttendeeTable, EventReportTable  # noqa: F401
     from v1.db.tables import ExternalEventDetailsTable, ExternalEventCategoryTable, ExternalEventAdminTable  # noqa: F401
     from v1.db.tables import ExternalRootTable, ExternalRootDateTable  # noqa: F401
+    from v1.db.tables import ExternalEventBookingTable  # noqa: F401
+    from v1.db.tables import FeedbackVoteTable, FeedbackUserIndexTable  # noqa: F401
 
-    Base.metadata.create_all(bind=engine)
-    logging.info("All database tables created.")
-
-    _seed_review_users()
+    for attempt in range(1, max_retries + 1):
+        try:
+            Base.metadata.create_all(bind=engine)
+            logging.info("All database tables created.")
+            _seed_review_users()
+            return
+        except Exception as e:
+            if attempt == max_retries:
+                logging.error(f"initialize_db failed after {max_retries} attempts: {e}")
+                raise
+            wait = retry_delay * (2 ** (attempt - 1))
+            logging.warning(f"initialize_db attempt {attempt} failed ({e}), retrying in {wait:.1f}s…")
+            time.sleep(wait)
 
 
 def _seed_review_users():

--- a/backend/v1/db/database.py
+++ b/backend/v1/db/database.py
@@ -2,7 +2,8 @@ import os
 import time
 import logging
 from contextlib import contextmanager
-from sqlalchemy import create_engine
+from pathlib import Path
+from sqlalchemy import create_engine, inspect
 from sqlalchemy.orm import sessionmaker, DeclarativeBase
 
 logging.basicConfig(level=logging.INFO)
@@ -36,8 +37,44 @@ def get_db():
         yield db
 
 
+def run_alembic_migrations():
+    """Apply all pending Alembic migrations to the live database.
+
+    Bootstrap handling: if the database already has tables but no
+    alembic_version table (i.e. it was created by the old create_all()
+    approach), stamp it at head so Alembic knows it is already up to date
+    without re-running the initial migration.
+    """
+    from alembic import command
+    from alembic.config import Config
+
+    # alembic.ini lives two levels above this file:
+    #   v1/db/database.py  →  ../../alembic.ini  →  backend/alembic.ini
+    alembic_ini = Path(__file__).resolve().parent.parent.parent / "alembic.ini"
+
+    alembic_cfg = Config(str(alembic_ini))
+
+    with engine.connect() as conn:
+        inspector = inspect(conn)
+        existing_tables = set(inspector.get_table_names())
+        has_alembic_version = "alembic_version" in existing_tables
+        has_app_tables = bool(existing_tables - {"alembic_version"})
+
+    if has_app_tables and not has_alembic_version:
+        # Pre-Alembic database — stamp as already at head so Alembic
+        # knows the initial migration has already been applied.
+        logging.info(
+            "Detected pre-Alembic database (tables exist, no alembic_version). "
+            "Stamping at head."
+        )
+        command.stamp(alembic_cfg, "head")
+
+    command.upgrade(alembic_cfg, "head")
+    logging.info("Alembic migrations applied (or already up to date).")
+
+
 def initialize_db(max_retries: int = 5, retry_delay: float = 2.0):
-    """Create all tables, retrying on connection failure."""
+    """Run Alembic migrations, retrying on connection failure."""
     from v1.db.tables import UserTable  # noqa: F401
     from v1.db.tables import TokenStorageTable  # noqa: F401
     from v1.db.tables import UserEventTable, EventHostTable, EventSuggestedHostTable, EventAttendeeTable, EventReportTable  # noqa: F401
@@ -48,8 +85,7 @@ def initialize_db(max_retries: int = 5, retry_delay: float = 2.0):
 
     for attempt in range(1, max_retries + 1):
         try:
-            Base.metadata.create_all(bind=engine)
-            logging.info("All database tables created.")
+            run_alembic_migrations()
             _seed_review_users()
             return
         except Exception as e:

--- a/backend/v1/db/database.py
+++ b/backend/v1/db/database.py
@@ -15,9 +15,14 @@ class Base(DeclarativeBase):
     pass
 
 
+def get_session():
+    """Return a new database session. Always call this instead of SessionLocal() directly."""
+    return SessionLocal()
+
+
 def get_db():
     """Yield a database session, closing it when done."""
-    db = SessionLocal()
+    db = get_session()
     try:
         yield db
     finally:
@@ -48,7 +53,7 @@ def _seed_review_users():
         return
 
     logging.info("Ensuring review users exist.")
-    with SessionLocal() as session:
+    with get_session() as session:
         for review_user in review_users:
             existing = session.query(UserTable).filter_by(userId=review_user.userId).first()
             user_data = review_user.model_dump()

--- a/backend/v1/db/external_bookings.py
+++ b/backend/v1/db/external_bookings.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import logging
 from typing import Dict, List, Set
-from v1.db.database import SessionLocal
+from v1.db.database import get_session
 from v1.db.tables import ExternalEventBookingTable
 
 
@@ -11,7 +11,7 @@ def upsert_user_bookings(userId: int, event_ids: List[int]) -> None:
         delete_user_bookings(userId)
         return
     try:
-        with SessionLocal() as session:
+        with get_session() as session:
             existing = {
                 row.eventId for row in
                 session.query(ExternalEventBookingTable.eventId)
@@ -34,7 +34,7 @@ def upsert_user_bookings(userId: int, event_ids: List[int]) -> None:
 def delete_user_bookings(userId: int) -> None:
     """Remove all booking records for a user."""
     try:
-        with SessionLocal() as session:
+        with get_session() as session:
             session.query(ExternalEventBookingTable).filter_by(userId=userId).delete()
             session.commit()
     except Exception as e:
@@ -44,7 +44,7 @@ def delete_user_bookings(userId: int) -> None:
 def delete_booking(userId: int, eventId: int) -> None:
     """Remove a single booking record."""
     try:
-        with SessionLocal() as session:
+        with get_session() as session:
             session.query(ExternalEventBookingTable).filter_by(
                 userId=userId, eventId=eventId
             ).delete()
@@ -56,7 +56,7 @@ def delete_booking(userId: int, eventId: int) -> None:
 def add_booking(userId: int, eventId: int) -> None:
     """Insert a single booking record (idempotent)."""
     try:
-        with SessionLocal() as session:
+        with get_session() as session:
             exists = session.query(ExternalEventBookingTable).filter_by(
                 userId=userId, eventId=eventId
             ).first()
@@ -72,7 +72,7 @@ def get_bookings_by_event_ids(event_ids: List[int]) -> Dict[int, Set[int]]:
     if not event_ids:
         return {}
     try:
-        with SessionLocal() as session:
+        with get_session() as session:
             rows = session.query(ExternalEventBookingTable).filter(
                 ExternalEventBookingTable.eventId.in_(event_ids)
             ).all()

--- a/backend/v1/db/external_bookings.py
+++ b/backend/v1/db/external_bookings.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 import logging
 from typing import Dict, List, Set
-from pymongo import UpdateOne
-from v1.db.mongo import external_event_bookings_collection
+from v1.db.database import SessionLocal
+from v1.db.tables import ExternalEventBookingTable
 
 
 def upsert_user_bookings(userId: int, event_ids: List[int]) -> None:
@@ -10,19 +10,23 @@ def upsert_user_bookings(userId: int, event_ids: List[int]) -> None:
     if not event_ids:
         delete_user_bookings(userId)
         return
-    ops = [
-        UpdateOne(
-            {"userId": userId, "eventId": eid},
-            {"$setOnInsert": {"userId": userId, "eventId": eid}},
-            upsert=True,
-        )
-        for eid in event_ids
-    ]
     try:
-        external_event_bookings_collection.bulk_write(ops, ordered=False)
-        external_event_bookings_collection.delete_many(
-            {"userId": userId, "eventId": {"$nin": event_ids}}
-        )
+        with SessionLocal() as session:
+            existing = {
+                row.eventId for row in
+                session.query(ExternalEventBookingTable.eventId)
+                .filter_by(userId=userId).all()
+            }
+            to_add = set(event_ids) - existing
+            to_remove = existing - set(event_ids)
+            for eid in to_add:
+                session.add(ExternalEventBookingTable(userId=userId, eventId=eid))
+            if to_remove:
+                session.query(ExternalEventBookingTable).filter(
+                    ExternalEventBookingTable.userId == userId,
+                    ExternalEventBookingTable.eventId.in_(to_remove),
+                ).delete(synchronize_session=False)
+            session.commit()
     except Exception as e:
         logging.error(f"[external_bookings] upsert_user_bookings failed for userId={userId}: {e}")
 
@@ -30,7 +34,9 @@ def upsert_user_bookings(userId: int, event_ids: List[int]) -> None:
 def delete_user_bookings(userId: int) -> None:
     """Remove all booking records for a user."""
     try:
-        external_event_bookings_collection.delete_many({"userId": userId})
+        with SessionLocal() as session:
+            session.query(ExternalEventBookingTable).filter_by(userId=userId).delete()
+            session.commit()
     except Exception as e:
         logging.error(f"[external_bookings] delete_user_bookings failed for userId={userId}: {e}")
 
@@ -38,7 +44,11 @@ def delete_user_bookings(userId: int) -> None:
 def delete_booking(userId: int, eventId: int) -> None:
     """Remove a single booking record."""
     try:
-        external_event_bookings_collection.delete_one({"userId": userId, "eventId": eventId})
+        with SessionLocal() as session:
+            session.query(ExternalEventBookingTable).filter_by(
+                userId=userId, eventId=eventId
+            ).delete()
+            session.commit()
     except Exception as e:
         logging.error(f"[external_bookings] delete_booking failed userId={userId} eventId={eventId}: {e}")
 
@@ -46,11 +56,13 @@ def delete_booking(userId: int, eventId: int) -> None:
 def add_booking(userId: int, eventId: int) -> None:
     """Insert a single booking record (idempotent)."""
     try:
-        external_event_bookings_collection.update_one(
-            {"userId": userId, "eventId": eventId},
-            {"$setOnInsert": {"userId": userId, "eventId": eventId}},
-            upsert=True,
-        )
+        with SessionLocal() as session:
+            exists = session.query(ExternalEventBookingTable).filter_by(
+                userId=userId, eventId=eventId
+            ).first()
+            if not exists:
+                session.add(ExternalEventBookingTable(userId=userId, eventId=eventId))
+                session.commit()
     except Exception as e:
         logging.error(f"[external_bookings] add_booking failed userId={userId} eventId={eventId}: {e}")
 
@@ -60,10 +72,14 @@ def get_bookings_by_event_ids(event_ids: List[int]) -> Dict[int, Set[int]]:
     if not event_ids:
         return {}
     try:
-        result: Dict[int, Set[int]] = {}
-        for doc in external_event_bookings_collection.find({"eventId": {"$in": event_ids}}):
-            result.setdefault(doc["eventId"], set()).add(doc["userId"])
-        return result
+        with SessionLocal() as session:
+            rows = session.query(ExternalEventBookingTable).filter(
+                ExternalEventBookingTable.eventId.in_(event_ids)
+            ).all()
+            result: Dict[int, Set[int]] = {}
+            for row in rows:
+                result.setdefault(row.eventId, set()).add(row.userId)
+            return result
     except Exception as e:
         logging.error(f"[external_bookings] get_bookings_by_event_ids failed: {e}")
         return {}

--- a/backend/v1/db/external_events.py
+++ b/backend/v1/db/external_events.py
@@ -1,67 +1,126 @@
 import logging
 from typing import List
+from sqlalchemy import or_
 from v1.db.models.external_events import ExternalEventDetails, ExternalRoot
-from v1.db.mongo import external_event_collection, external_root_collection
+from v1.db.database import SessionLocal
+from v1.db.tables import (
+    ExternalEventDetailsTable, ExternalEventAdminTable, ExternalEventCategoryTable,
+    ExternalRootTable, ExternalRootDateTable,
+)
 
 
 def store_external_root(root: ExternalRoot):
-    """
-    Stores the external root details in the MongoDB database.
-
-    :param root: The external root details.
-    """
+    """Stores or replaces the external root details."""
     try:
         root_dict = root.model_dump()
-        external_root_collection.update_one(
-            {},  # empty filter to match all documents
-            {'$set': root_dict},  # update
-            upsert=True  # insert if doesn't exist
-        )
+        with SessionLocal() as session:
+            existing = session.query(ExternalRootTable).first()
+            if existing:
+                for key in ("version", "loginUrl", "restUrl", "siteUrl", "header1", "header2", "city", "streetAddress", "mapUrl"):
+                    setattr(existing, key, root_dict[key])
+                existing.dates.clear()
+                for d in root_dict.get("dates", []):
+                    existing.dates.append(ExternalRootDateTable(root_id=existing.id, date_value=d))
+            else:
+                row = ExternalRootTable(
+                    version=root_dict["version"],
+                    loginUrl=root_dict["loginUrl"],
+                    restUrl=root_dict["restUrl"],
+                    siteUrl=root_dict["siteUrl"],
+                    header1=root_dict["header1"],
+                    header2=root_dict["header2"],
+                    city=root_dict["city"],
+                    streetAddress=root_dict["streetAddress"],
+                    mapUrl=root_dict["mapUrl"],
+                )
+                session.add(row)
+                session.flush()
+                for d in root_dict.get("dates", []):
+                    session.add(ExternalRootDateTable(root_id=row.id, date_value=d))
+            session.commit()
         logging.info("Successfully stored external root details.")
     except Exception as e:
         logging.error(f"Failed to store external root details: {e}")
 
-def get_stored_external_root() -> ExternalRoot:
-    """
-    Retrieves the stored external root details from the MongoDB database.
 
-    :return: The external root details.
-    """
+def get_stored_external_root() -> ExternalRoot | None:
+    """Retrieves the stored external root details."""
     try:
-        root_data = external_root_collection.find_one({})
-        if root_data:
-            return ExternalRoot(**root_data)
-        else:
-            logging.info("No external root data found.")
-            return None
+        with SessionLocal() as session:
+            row = session.query(ExternalRootTable).first()
+            if row:
+                return ExternalRoot(**row.to_dict())
+            else:
+                logging.info("No external root data found.")
+                return None
     except Exception as e:
         logging.error(f"Failed to retrieve external root details: {e}")
         return None
 
 
 def store_external_event_details(events: List[ExternalEventDetails]):
-    """
-    Stores external event details in the MongoDB database.
-
-    :param event: The external event details.
-    """
-    # not yet sure if i want to update or not so thats why this is still here.
-    # try:
-    #     external_event_collection.insert_many(event.model_dump() for event in events)
-    # except Exception as e:
-    #     logging.error(f"Failed to insert events: {e}")
-
-    ## Update the existing event if it exists, otherwise insert a new event
+    """Stores external event details (upsert)."""
     try:
-        for event in events:
-            event_dict = event.model_dump()
-            # Print the title
-            logging.info(f"Storing event: {event_dict['titel']}")
-            external_event_collection.update_one(
-                {'eventId': event_dict['eventId']},  # filter
-                {'$set': event_dict},  # update
-                upsert=True  # insert if doesn't exist
-            )
+        with SessionLocal() as session:
+            for event in events:
+                event_dict = event.model_dump()
+                logging.info(f"Storing event: {event_dict['titel']}")
+
+                existing = session.query(ExternalEventDetailsTable).filter_by(
+                    eventId=event_dict["eventId"]
+                ).first()
+
+                if existing:
+                    for key in ("eventDate", "startTime", "endTime", "titel", "description",
+                                "speaker", "location", "locationInfo", "mapUrl",
+                                "isFree", "price", "isLimited", "stock", "showBooked",
+                                "booked", "dateBookingStart", "dateBookingEnd",
+                                "imageUrl150", "imageUrl300", "eventUrl"):
+                        setattr(existing, key, event_dict.get(key))
+
+                    existing.admins.clear()
+                    for admin_id in event_dict.get("admins") or []:
+                        existing.admins.append(ExternalEventAdminTable(eventId=existing.eventId, admin_id=admin_id))
+
+                    existing.categories.clear()
+                    for cat in event_dict.get("categories") or []:
+                        existing.categories.append(ExternalEventCategoryTable(
+                            eventId=existing.eventId, **cat
+                        ))
+                else:
+                    row = ExternalEventDetailsTable(
+                        eventId=event_dict["eventId"],
+                        eventDate=event_dict.get("eventDate"),
+                        startTime=event_dict["startTime"],
+                        endTime=event_dict["endTime"],
+                        titel=event_dict.get("titel"),
+                        description=event_dict["description"],
+                        speaker=event_dict["speaker"],
+                        location=event_dict["location"],
+                        locationInfo=event_dict.get("locationInfo"),
+                        mapUrl=event_dict.get("mapUrl"),
+                        isFree=event_dict["isFree"],
+                        price=event_dict["price"],
+                        isLimited=event_dict["isLimited"],
+                        stock=event_dict["stock"],
+                        showBooked=event_dict["showBooked"],
+                        booked=event_dict["booked"],
+                        dateBookingStart=event_dict.get("dateBookingStart"),
+                        dateBookingEnd=event_dict.get("dateBookingEnd"),
+                        imageUrl150=event_dict.get("imageUrl150"),
+                        imageUrl300=event_dict.get("imageUrl300"),
+                        eventUrl=event_dict["eventUrl"],
+                    )
+                    session.add(row)
+                    session.flush()
+
+                    for admin_id in event_dict.get("admins") or []:
+                        session.add(ExternalEventAdminTable(eventId=row.eventId, admin_id=admin_id))
+
+                    for cat in event_dict.get("categories") or []:
+                        session.add(ExternalEventCategoryTable(eventId=row.eventId, **cat))
+
+            session.commit()
     except Exception as e:
         logging.error(f"Failed to insert/update events: {e}")
 
@@ -70,48 +129,50 @@ def get_stored_external_event_details(
         event_ids: List[int],
         host_id: int = None,
     ) -> List[ExternalEventDetails]:
-    """
-    Retrieves external event details from the MongoDB database.
-
-    :param event_ids: The external event IDs.
-    :return: The external event details.
-    """
+    """Retrieves external event details by event IDs or admin host ID."""
     try:
-        return [
-            ExternalEventDetails(**event) for event in
-            external_event_collection.find({
-                "$or": [
-                    {"eventId": {"$in": event_ids}},
-                    {"admins": f"{host_id}"}
+        with SessionLocal() as session:
+            conditions = [ExternalEventDetailsTable.eventId.in_(event_ids)]
+            if host_id is not None:
+                # Find events where host_id is an admin
+                admin_event_ids = [
+                    row.eventId for row in
+                    session.query(ExternalEventAdminTable.eventId).filter(
+                        ExternalEventAdminTable.admin_id == str(host_id)
+                    ).all()
                 ]
-            })
-        ]
+                if admin_event_ids:
+                    conditions.append(ExternalEventDetailsTable.eventId.in_(admin_event_ids))
+
+            rows = session.query(ExternalEventDetailsTable).filter(
+                or_(*conditions)
+            ).all()
+            return [ExternalEventDetails(**row.to_dict()) for row in rows]
     except Exception as e:
         logging.error(f"Failed to retrieve events: {e}")
         return []
 
 
 def get_all_stored_external_event_details() -> List[ExternalEventDetails]:
-    """Return all stored external events from MongoDB."""
+    """Return all stored external events."""
     try:
-        return [ExternalEventDetails(**event) for event in external_event_collection.find({})]
+        with SessionLocal() as session:
+            rows = session.query(ExternalEventDetailsTable).all()
+            return [ExternalEventDetails(**row.to_dict()) for row in rows]
     except Exception as e:
         logging.error(f"Failed to retrieve all external events: {e}")
         return []
 
-def clean_external_events(keeping: List[ExternalEventDetails]):
-    """
-    Cleans the external events in the MongoDB database.
 
-    :param keeping: The external event details to keep.
-    """
+def clean_external_events(keeping: List[ExternalEventDetails]):
+    """Deletes external events not in the keeping list."""
     try:
-        # Get all event IDs to keep
         keeping_ids = [event.eventId for event in keeping]
-        # Delete all events that are not in the keeping list
-        external_event_collection.delete_many({
-            "eventId": {"$nin": keeping_ids}
-        })
+        with SessionLocal() as session:
+            session.query(ExternalEventDetailsTable).filter(
+                ~ExternalEventDetailsTable.eventId.in_(keeping_ids)
+            ).delete(synchronize_session="fetch")
+            session.commit()
         logging.info("Successfully cleaned external events.")
     except Exception as e:
         logging.error(f"Failed to clean external events: {e}")

--- a/backend/v1/db/external_events.py
+++ b/backend/v1/db/external_events.py
@@ -2,7 +2,7 @@ import logging
 from typing import List
 from sqlalchemy import or_
 from v1.db.models.external_events import ExternalEventDetails, ExternalRoot
-from v1.db.database import SessionLocal
+from v1.db.database import get_session
 from v1.db.tables import (
     ExternalEventDetailsTable, ExternalEventAdminTable, ExternalEventCategoryTable,
     ExternalRootTable, ExternalRootDateTable,
@@ -13,7 +13,7 @@ def store_external_root(root: ExternalRoot):
     """Stores or replaces the external root details."""
     try:
         root_dict = root.model_dump()
-        with SessionLocal() as session:
+        with get_session() as session:
             existing = session.query(ExternalRootTable).first()
             if existing:
                 for key in ("version", "loginUrl", "restUrl", "siteUrl", "header1", "header2", "city", "streetAddress", "mapUrl"):
@@ -46,7 +46,7 @@ def store_external_root(root: ExternalRoot):
 def get_stored_external_root() -> ExternalRoot | None:
     """Retrieves the stored external root details."""
     try:
-        with SessionLocal() as session:
+        with get_session() as session:
             row = session.query(ExternalRootTable).first()
             if row:
                 return ExternalRoot(**row.to_dict())
@@ -61,7 +61,7 @@ def get_stored_external_root() -> ExternalRoot | None:
 def store_external_event_details(events: List[ExternalEventDetails]):
     """Stores external event details (upsert)."""
     try:
-        with SessionLocal() as session:
+        with get_session() as session:
             for event in events:
                 event_dict = event.model_dump()
                 logging.info(f"Storing event: {event_dict['titel']}")
@@ -131,7 +131,7 @@ def get_stored_external_event_details(
     ) -> List[ExternalEventDetails]:
     """Retrieves external event details by event IDs or admin host ID."""
     try:
-        with SessionLocal() as session:
+        with get_session() as session:
             conditions = [ExternalEventDetailsTable.eventId.in_(event_ids)]
             if host_id is not None:
                 # Find events where host_id is an admin
@@ -156,7 +156,7 @@ def get_stored_external_event_details(
 def get_all_stored_external_event_details() -> List[ExternalEventDetails]:
     """Return all stored external events."""
     try:
-        with SessionLocal() as session:
+        with get_session() as session:
             rows = session.query(ExternalEventDetailsTable).all()
             return [ExternalEventDetails(**row.to_dict()) for row in rows]
     except Exception as e:
@@ -168,7 +168,7 @@ def clean_external_events(keeping: List[ExternalEventDetails]):
     """Deletes external events not in the keeping list."""
     try:
         keeping_ids = [event.eventId for event in keeping]
-        with SessionLocal() as session:
+        with get_session() as session:
             session.query(ExternalEventDetailsTable).filter(
                 ~ExternalEventDetailsTable.eventId.in_(keeping_ids)
             ).delete(synchronize_session="fetch")

--- a/backend/v1/db/external_events.py
+++ b/backend/v1/db/external_events.py
@@ -59,13 +59,12 @@ def get_stored_external_root() -> ExternalRoot | None:
 
 
 def store_external_event_details(events: List[ExternalEventDetails]):
-    """Stores external event details (upsert)."""
-    try:
-        with get_session() as session:
-            for event in events:
-                event_dict = event.model_dump()
-                logging.info(f"Storing event: {event_dict['titel']}")
-
+    """Stores external event details (upsert), one transaction per event."""
+    for event in events:
+        event_dict = event.model_dump()
+        logging.info(f"Storing event: {event_dict['titel']}")
+        try:
+            with get_session() as session:
                 existing = session.query(ExternalEventDetailsTable).filter_by(
                     eventId=event_dict["eventId"]
                 ).first()
@@ -120,9 +119,9 @@ def store_external_event_details(events: List[ExternalEventDetails]):
                     for cat in event_dict.get("categories") or []:
                         session.add(ExternalEventCategoryTable(eventId=row.eventId, **cat))
 
-            session.commit()
-    except Exception as e:
-        logging.error(f"Failed to insert/update events: {e}")
+                session.commit()
+        except Exception as e:
+            logging.error(f"Failed to insert/update event {event_dict.get('eventId')}: {e}")
 
 
 def get_stored_external_event_details(

--- a/backend/v1/db/external_token_storage.py
+++ b/backend/v1/db/external_token_storage.py
@@ -3,23 +3,24 @@ Token storage using PostgreSQL via SQLAlchemy.
 """
 from datetime import datetime
 from v1.db.models.tokenstorage import TokenStorage
-from v1.db.database import SessionLocal
+from v1.db.database import get_session
 from v1.db.tables import TokenStorageTable
 from v1.utilities import convert_to_tz_aware, get_current_time
 
 
 def save_external_token(user_id: int, external_token: str,
                         expires_at: datetime):
+    now = get_current_time()
     token = TokenStorage.model_validate({
         "userId": user_id,
         "externalAccessToken": external_token,
-        "createdAt": convert_to_tz_aware(get_current_time()),
-        "expiresAt": convert_to_tz_aware(expires_at),
+        "createdAt": now,
+        "expiresAt": expires_at if expires_at.tzinfo else expires_at.replace(tzinfo=now.tzinfo),
     })
 
     token_data = token.model_dump()
 
-    with SessionLocal() as session:
+    with get_session() as session:
         existing = session.query(TokenStorageTable).filter_by(userId=user_id).first()
         if existing:
             existing.externalAccessToken = token_data["externalAccessToken"]
@@ -31,12 +32,16 @@ def save_external_token(user_id: int, external_token: str,
 
 
 def get_external_token(user_id: int):
-    with SessionLocal() as session:
+    with get_session() as session:
         row = session.query(TokenStorageTable).filter_by(userId=user_id).first()
         if not row:
             return None
 
-        expires_at_tz_aware = convert_to_tz_aware(row.expiresAt)
+        # Compare as naive datetimes in the same timezone
+        now = get_current_time().replace(tzinfo=None)
+        expires_at = row.expiresAt if isinstance(row.expiresAt, datetime) else row.expiresAt
+        if isinstance(expires_at, datetime) and expires_at.tzinfo is not None:
+            expires_at = expires_at.replace(tzinfo=None)
 
-        if expires_at_tz_aware > get_current_time():
+        if expires_at > now:
             return row.externalAccessToken

--- a/backend/v1/db/external_token_storage.py
+++ b/backend/v1/db/external_token_storage.py
@@ -1,47 +1,47 @@
-"""
-Token storage using PostgreSQL via SQLAlchemy.
-"""
-from datetime import datetime
+"""Token storage using PostgreSQL via SQLAlchemy."""
+from datetime import datetime, timezone
 from v1.db.models.tokenstorage import TokenStorage
 from v1.db.database import get_session
 from v1.db.tables import TokenStorageTable
-from v1.utilities import convert_to_tz_aware, get_current_time
 
 
-def save_external_token(user_id: int, external_token: str,
-                        expires_at: datetime):
-    now = get_current_time()
-    token = TokenStorage.model_validate({
-        "userId": user_id,
-        "externalAccessToken": external_token,
-        "createdAt": now,
-        "expiresAt": expires_at if expires_at.tzinfo else expires_at.replace(tzinfo=now.tzinfo),
-    })
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
 
-    token_data = token.model_dump()
+
+def _ensure_utc(dt: datetime) -> datetime:
+    """Return dt as a UTC-aware datetime, treating naive datetimes as UTC."""
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def save_external_token(user_id: int, external_token: str, expires_at: datetime) -> None:
+    now = _utc_now()
+    expires_utc = _ensure_utc(expires_at)
 
     with get_session() as session:
         existing = session.query(TokenStorageTable).filter_by(userId=user_id).first()
         if existing:
-            existing.externalAccessToken = token_data["externalAccessToken"]
-            existing.createdAt = token_data["createdAt"]
-            existing.expiresAt = token_data["expiresAt"]
+            existing.externalAccessToken = external_token
+            existing.createdAt = now
+            existing.expiresAt = expires_utc
         else:
-            session.add(TokenStorageTable(**token_data))
+            session.add(TokenStorageTable(
+                userId=user_id,
+                externalAccessToken=external_token,
+                createdAt=now,
+                expiresAt=expires_utc,
+            ))
         session.commit()
 
 
-def get_external_token(user_id: int):
+def get_external_token(user_id: int) -> str | None:
     with get_session() as session:
         row = session.query(TokenStorageTable).filter_by(userId=user_id).first()
         if not row:
             return None
-
-        # Compare as naive datetimes in the same timezone
-        now = get_current_time().replace(tzinfo=None)
-        expires_at = row.expiresAt if isinstance(row.expiresAt, datetime) else row.expiresAt
-        if isinstance(expires_at, datetime) and expires_at.tzinfo is not None:
-            expires_at = expires_at.replace(tzinfo=None)
-
-        if expires_at > now:
+        expires_utc = _ensure_utc(row.expiresAt) if isinstance(row.expiresAt, datetime) else None
+        if expires_utc and expires_utc > _utc_now():
             return row.externalAccessToken
+        return None

--- a/backend/v1/db/external_token_storage.py
+++ b/backend/v1/db/external_token_storage.py
@@ -1,58 +1,42 @@
 """
-This module contains functions for saving and retrieving external tokens in a MongoDB collection.
-
-The `save_external_token` function saves an external token for a user in the collection. 
-It takes a user ID, an external token, and an expiration datetime as arguments. The function first 
-converts the current time and the expiration datetime to timezone-aware datetime objects, 
-because MongoDB requires datetime objects to be timezone-aware. It then creates a new document 
-with the user ID, the external token, and the timezone-aware datetimes, and upserts it into the collection.
-
-The `get_external_token` function retrieves the external token for a user from the collection. It takes a 
-user ID as an argument, and returns the document for the user from the collection. The function also converts 
-the `createdAt` and `expiresAt` fields in the document to timezone-aware datetime objects, because 
-MongoDB returns these fields as naive datetime objects.
-
-The `convert_to_tz_aware` function is used to convert a naive datetime object to a timezone-aware datetime object. 
-It takes a naive datetime object as an argument, and returns a timezone-aware datetime object in the same timezone 
-as the current time.
-
-The `get_current_time` function returns the current time as a timezone-aware datetime object.
+Token storage using PostgreSQL via SQLAlchemy.
 """
 from datetime import datetime
 from v1.db.models.tokenstorage import TokenStorage
-from v1.db.mongo import tokenstorage_collection
+from v1.db.database import SessionLocal
+from v1.db.tables import TokenStorageTable
 from v1.utilities import convert_to_tz_aware, get_current_time
 
 
 def save_external_token(user_id: int, external_token: str,
                         expires_at: datetime):
     token = TokenStorage.model_validate({
-        "userId":
-        user_id,
-        "externalAccessToken":
-        external_token,
-        "createdAt":
-        convert_to_tz_aware(get_current_time()),
-        "expiresAt":
-        convert_to_tz_aware(expires_at)
+        "userId": user_id,
+        "externalAccessToken": external_token,
+        "createdAt": convert_to_tz_aware(get_current_time()),
+        "expiresAt": convert_to_tz_aware(expires_at),
     })
 
-    tokenjson = token.model_dump()
+    token_data = token.model_dump()
 
-    # Upsert option to ensure no duplicate entries for the same user
-    tokenstorage_collection.update_one({"userId": tokenjson["userId"]},
-                                       {"$set": tokenjson},
-                                       upsert=True)
+    with SessionLocal() as session:
+        existing = session.query(TokenStorageTable).filter_by(userId=user_id).first()
+        if existing:
+            existing.externalAccessToken = token_data["externalAccessToken"]
+            existing.createdAt = token_data["createdAt"]
+            existing.expiresAt = token_data["expiresAt"]
+        else:
+            session.add(TokenStorageTable(**token_data))
+        session.commit()
 
 
 def get_external_token(user_id: int):
-    token_info = tokenstorage_collection.find_one({"userId": user_id})
-    if not token_info:
-        # TODO: Token is expired or not found, request new token
-        return None
+    with SessionLocal() as session:
+        row = session.query(TokenStorageTable).filter_by(userId=user_id).first()
+        if not row:
+            return None
 
-    expires_at_tz_aware = convert_to_tz_aware(token_info['expiresAt'])
-    created_at_tz_aware = convert_to_tz_aware(token_info['createdAt'])
+        expires_at_tz_aware = convert_to_tz_aware(row.expiresAt)
 
-    if expires_at_tz_aware > get_current_time():
-        return token_info['externalAccessToken']
+        if expires_at_tz_aware > get_current_time():
+            return row.externalAccessToken

--- a/backend/v1/db/feedback_user_index.py
+++ b/backend/v1/db/feedback_user_index.py
@@ -1,58 +1,49 @@
-"""Persisted map from the public feedback `user_hash` to the actual user.
-
-The hash is intentionally one-way (HMAC) so it can sit publicly on GitHub
-without leaking PII. But admins legitimately need to look up *who* posted
-a given issue or comment — to contact someone, follow up on a bug
-report, or moderate abuse. This collection holds that mapping so the
-admin can paste a hash from a GitHub issue and recover the user_id /
-member_number.
-
-Stored fields are deliberately minimal: no message bodies, just identity
-and timestamps. Treat as a moderation tool, not analytics.
-"""
+"""Persisted map from public feedback user_hash to actual user (moderation tool)."""
 import datetime
 import logging
 
-from pymongo import ASCENDING
-
-from v1.db.mongo import db
+from v1.db.database import get_session
+from v1.db.tables import FeedbackUserIndexTable
 
 logger = logging.getLogger(__name__)
-
-feedback_user_index_collection = db["feedback_user_index"]
-
-
-def initialize_indexes() -> None:
-    feedback_user_index_collection.create_index(
-        [("user_hash", ASCENDING)], unique=True
-    )
-    feedback_user_index_collection.create_index([("user_id", ASCENDING)])
 
 
 def register_user(user: dict, user_hash: str) -> None:
     """Upsert (user_hash → user_id) and bump last_seen on every feedback action."""
-    now = datetime.datetime.utcnow()
-    update = {
-        "$setOnInsert": {
-            "user_hash": user_hash,
-            "first_seen": now,
-        },
-        "$set": {
-            "user_id": user.get("userId"),
-            "member_number": user.get("memberNumber") or user.get("member_number"),
-            "is_member": user.get("isMember", False),
-            "last_seen": now,
-        },
-    }
+    now = datetime.datetime.now(datetime.timezone.utc)
     try:
-        feedback_user_index_collection.update_one(
-            {"user_hash": user_hash}, update, upsert=True
-        )
+        with get_session() as session:
+            row = session.query(FeedbackUserIndexTable).filter_by(user_hash=user_hash).first()
+            if row:
+                row.user_id = user.get("userId")
+                row.member_number = user.get("memberNumber") or user.get("member_number")
+                row.is_member = user.get("isMember", False)
+                row.last_seen = now
+            else:
+                row = FeedbackUserIndexTable(
+                    user_hash=user_hash,
+                    user_id=user.get("userId"),
+                    member_number=user.get("memberNumber") or user.get("member_number"),
+                    is_member=user.get("isMember", False),
+                    first_seen=now,
+                    last_seen=now,
+                )
+                session.add(row)
+            session.commit()
     except Exception:
         logger.exception("Failed to upsert feedback_user_index entry")
 
 
 def lookup(user_hash: str) -> dict | None:
-    return feedback_user_index_collection.find_one(
-        {"user_hash": user_hash}, {"_id": 0}
-    )
+    with get_session() as session:
+        row = session.query(FeedbackUserIndexTable).filter_by(user_hash=user_hash).first()
+        if not row:
+            return None
+        return {
+            "user_hash": row.user_hash,
+            "user_id": row.user_id,
+            "member_number": row.member_number,
+            "is_member": row.is_member,
+            "first_seen": row.first_seen,
+            "last_seen": row.last_seen,
+        }

--- a/backend/v1/db/feedback_votes.py
+++ b/backend/v1/db/feedback_votes.py
@@ -1,76 +1,46 @@
 from typing import Literal
-from pymongo import ASCENDING
-
-from v1.db.mongo import db
-
-feedback_votes_collection = db["feedback_votes"]
-
-
-def initialize_indexes() -> None:
-    feedback_votes_collection.create_index(
-        [("issue_number", ASCENDING), ("user_hash", ASCENDING)],
-        unique=True,
-    )
-    feedback_votes_collection.create_index([("issue_number", ASCENDING)])
+from v1.db.database import get_session
+from v1.db.tables import FeedbackVoteTable
 
 
 def set_vote(issue_number: int, user_hash: str, value: Literal[-1, 0, 1]) -> None:
-    if value == 0:
-        feedback_votes_collection.delete_one(
-            {"issue_number": issue_number, "user_hash": user_hash}
-        )
-        return
-    feedback_votes_collection.update_one(
-        {"issue_number": issue_number, "user_hash": user_hash},
-        {"$set": {"value": value}},
-        upsert=True,
-    )
+    with get_session() as session:
+        row = session.query(FeedbackVoteTable).filter_by(
+            issue_number=issue_number, user_hash=user_hash
+        ).first()
+        if value == 0:
+            if row:
+                session.delete(row)
+        elif row:
+            row.value = value
+        else:
+            session.add(FeedbackVoteTable(
+                issue_number=issue_number, user_hash=user_hash, value=value
+            ))
+        session.commit()
 
 
 def get_tally(issue_number: int, user_hash: str) -> dict:
-    up = feedback_votes_collection.count_documents(
-        {"issue_number": issue_number, "value": 1}
-    )
-    down = feedback_votes_collection.count_documents(
-        {"issue_number": issue_number, "value": -1}
-    )
-    mine_doc = feedback_votes_collection.find_one(
-        {"issue_number": issue_number, "user_hash": user_hash}
-    )
-    return {
-        "up": up,
-        "down": down,
-        "score": up - down,
-        "my_vote": mine_doc["value"] if mine_doc else 0,
-    }
+    with get_session() as session:
+        rows = session.query(FeedbackVoteTable).filter_by(issue_number=issue_number).all()
+        up = sum(1 for r in rows if r.value == 1)
+        down = sum(1 for r in rows if r.value == -1)
+        mine = next((r.value for r in rows if r.user_hash == user_hash), 0)
+        return {"up": up, "down": down, "score": up - down, "my_vote": mine}
 
 
 def get_tallies(issue_numbers: list[int], user_hash: str) -> dict[int, dict]:
     if not issue_numbers:
         return {}
-    pipeline = [
-        {"$match": {"issue_number": {"$in": issue_numbers}}},
-        {
-            "$group": {
-                "_id": "$issue_number",
-                "up": {"$sum": {"$cond": [{"$eq": ["$value", 1]}, 1, 0]}},
-                "down": {"$sum": {"$cond": [{"$eq": ["$value", -1]}, 1, 0]}},
-            }
-        },
-    ]
-    aggregated = {
-        d["_id"]: {"up": d["up"], "down": d["down"], "score": d["up"] - d["down"]}
-        for d in feedback_votes_collection.aggregate(pipeline)
-    }
-    my_votes = {
-        d["issue_number"]: d["value"]
-        for d in feedback_votes_collection.find(
-            {"issue_number": {"$in": issue_numbers}, "user_hash": user_hash}
-        )
-    }
-    result: dict[int, dict] = {}
-    for n in issue_numbers:
-        t = aggregated.get(n, {"up": 0, "down": 0, "score": 0})
-        t["my_vote"] = my_votes.get(n, 0)
-        result[n] = t
-    return result
+    with get_session() as session:
+        rows = session.query(FeedbackVoteTable).filter(
+            FeedbackVoteTable.issue_number.in_(issue_numbers)
+        ).all()
+        result: dict[int, dict] = {}
+        for n in issue_numbers:
+            group = [r for r in rows if r.issue_number == n]
+            up = sum(1 for r in group if r.value == 1)
+            down = sum(1 for r in group if r.value == -1)
+            mine = next((r.value for r in group if r.user_hash == user_hash), 0)
+            result[n] = {"up": up, "down": down, "score": up - down, "my_vote": mine}
+        return result

--- a/backend/v1/db/tables.py
+++ b/backend/v1/db/tables.py
@@ -1,0 +1,346 @@
+"""SQLAlchemy table definitions for all database models."""
+
+from sqlalchemy import (
+    Column, Integer, String, Boolean, Float, DateTime, Text, ForeignKey, JSON, UniqueConstraint
+)
+from sqlalchemy.orm import relationship
+from v1.db.database import Base
+
+
+# ── User ──────────────────────────────────────────────────────────────────────
+
+class UserTable(Base):
+    __tablename__ = "users"
+
+    userId = Column(Integer, primary_key=True)
+    isMember = Column(Boolean, default=False, nullable=False)
+
+    # Settings (flattened from UserSettings)
+    show_location = Column(String, default="NO_ONE", nullable=False)
+    show_email = Column(Boolean, default=False, nullable=False)
+    show_phone = Column(Boolean, default=False, nullable=False)
+    location_update_interval_seconds = Column(Integer, default=60, nullable=False)
+    events_refresh_interval_seconds = Column(Integer, default=60, nullable=False)
+    background_location_updates = Column(Boolean, default=False, nullable=False)
+
+    # Location (nullable)
+    location_latitude = Column(Float, nullable=True)
+    location_longitude = Column(Float, nullable=True)
+    location_timestamp = Column(DateTime, nullable=True)
+    location_accuracy = Column(Float, nullable=True)
+
+    # Contact info
+    contact_email = Column(String, nullable=True)
+    contact_phone = Column(String, nullable=True)
+
+    # Profile
+    age = Column(Integer, nullable=True)
+    slogan = Column(String, nullable=True)
+    avatar_url = Column(String, nullable=True)
+    firstName = Column(String, nullable=True)
+    lastName = Column(String, nullable=True)
+
+    @classmethod
+    def from_pydantic(cls, user):
+        """Create a UserTable row from a Pydantic User model."""
+        return cls(
+            userId=user.userId,
+            isMember=user.isMember,
+            show_location=user.settings.show_location.value if user.settings else "NO_ONE",
+            show_email=user.settings.show_email if user.settings else False,
+            show_phone=user.settings.show_phone if user.settings else False,
+            location_update_interval_seconds=user.settings.location_update_interval_seconds if user.settings else 60,
+            events_refresh_interval_seconds=user.settings.events_refresh_interval_seconds if user.settings else 60,
+            background_location_updates=user.settings.background_location_updates if user.settings else False,
+            location_latitude=user.location.latitude if user.location else None,
+            location_longitude=user.location.longitude if user.location else None,
+            location_timestamp=user.location.timestamp if user.location else None,
+            location_accuracy=user.location.accuracy if user.location else None,
+            contact_email=user.contact_info.email if user.contact_info else None,
+            contact_phone=user.contact_info.phone if user.contact_info else None,
+            age=user.age,
+            slogan=user.slogan,
+            avatar_url=user.avatar_url,
+            firstName=user.firstName,
+            lastName=user.lastName,
+        )
+
+    def to_dict(self):
+        """Convert to a dict matching the Pydantic User model shape."""
+        result = {
+            "userId": self.userId,
+            "isMember": self.isMember,
+            "settings": {
+                "show_location": self.show_location,
+                "show_email": self.show_email,
+                "show_phone": self.show_phone,
+                "location_update_interval_seconds": self.location_update_interval_seconds,
+                "events_refresh_interval_seconds": self.events_refresh_interval_seconds,
+                "background_location_updates": self.background_location_updates,
+            },
+            "age": self.age,
+            "slogan": self.slogan,
+            "avatar_url": self.avatar_url,
+            "firstName": self.firstName,
+            "lastName": self.lastName,
+        }
+        if self.location_latitude is not None:
+            result["location"] = {
+                "latitude": self.location_latitude,
+                "longitude": self.location_longitude,
+                "timestamp": self.location_timestamp,
+                "accuracy": self.location_accuracy,
+            }
+        else:
+            result["location"] = None
+
+        if self.contact_email is not None or self.contact_phone is not None:
+            result["contact_info"] = {
+                "email": self.contact_email,
+                "phone": self.contact_phone,
+            }
+        else:
+            result["contact_info"] = None
+
+        return result
+
+
+# ── Token Storage ─────────────────────────────────────────────────────────────
+
+class TokenStorageTable(Base):
+    __tablename__ = "token_storage"
+
+    userId = Column(Integer, primary_key=True)
+    externalAccessToken = Column(String, nullable=False)
+    createdAt = Column(DateTime, nullable=False)
+    expiresAt = Column(DateTime, nullable=False)
+
+
+# ── User Events ───────────────────────────────────────────────────────────────
+
+class UserEventTable(Base):
+    __tablename__ = "user_events"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    userId = Column(Integer, nullable=False)
+    name = Column(String, nullable=False)
+    start = Column(DateTime, nullable=False)
+    end = Column(DateTime, nullable=True)
+    description = Column(Text, nullable=True)
+    maxAttendees = Column(Integer, nullable=True)
+
+    # Location (flattened)
+    location_description = Column(String, nullable=True)
+    location_address = Column(String, nullable=True)
+    location_marker = Column(String, nullable=True)
+    location_latitude = Column(Float, nullable=True)
+    location_longitude = Column(Float, nullable=True)
+
+    # Relationships
+    hosts = relationship("EventHostTable", back_populates="event", cascade="all, delete-orphan")
+    suggested_hosts = relationship("EventSuggestedHostTable", back_populates="event", cascade="all, delete-orphan")
+    attendees = relationship("EventAttendeeTable", back_populates="event", cascade="all, delete-orphan")
+    reports = relationship("EventReportTable", back_populates="event", cascade="all, delete-orphan")
+
+    def to_dict(self):
+        """Convert to a dict matching the Pydantic UserEvent model shape."""
+        location = None
+        if any([self.location_description, self.location_address, self.location_latitude]):
+            location = {
+                "description": self.location_description,
+                "address": self.location_address,
+                "marker": self.location_marker,
+                "latitude": self.location_latitude,
+                "longitude": self.location_longitude,
+            }
+        return {
+            "_id": str(self.id),
+            "userId": self.userId,
+            "name": self.name,
+            "start": self.start,
+            "end": self.end,
+            "description": self.description,
+            "maxAttendees": self.maxAttendees,
+            "location": location,
+            "hosts": [{"userId": h.userId} for h in self.hosts],
+            "suggested_hosts": [{"userId": h.userId} for h in self.suggested_hosts],
+            "attendees": [{"userId": a.userId} for a in self.attendees],
+            "reports": [{"userId": r.userId, "text": r.text} for r in self.reports],
+        }
+
+
+class EventHostTable(Base):
+    __tablename__ = "event_hosts"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    event_id = Column(Integer, ForeignKey("user_events.id", ondelete="CASCADE"), nullable=False)
+    userId = Column(Integer, nullable=False)
+
+    event = relationship("UserEventTable", back_populates="hosts")
+
+
+class EventSuggestedHostTable(Base):
+    __tablename__ = "event_suggested_hosts"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    event_id = Column(Integer, ForeignKey("user_events.id", ondelete="CASCADE"), nullable=False)
+    userId = Column(Integer, nullable=False)
+
+    event = relationship("UserEventTable", back_populates="suggested_hosts")
+
+
+class EventAttendeeTable(Base):
+    __tablename__ = "event_attendees"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    event_id = Column(Integer, ForeignKey("user_events.id", ondelete="CASCADE"), nullable=False)
+    userId = Column(Integer, nullable=False)
+
+    event = relationship("UserEventTable", back_populates="attendees")
+
+
+class EventReportTable(Base):
+    __tablename__ = "event_reports"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    event_id = Column(Integer, ForeignKey("user_events.id", ondelete="CASCADE"), nullable=False)
+    userId = Column(Integer, nullable=False)
+    text = Column(Text, nullable=False)
+
+    event = relationship("UserEventTable", back_populates="reports")
+
+
+# ── External Events ───────────────────────────────────────────────────────────
+
+class ExternalEventDetailsTable(Base):
+    __tablename__ = "external_event_details"
+
+    eventId = Column(Integer, primary_key=True)
+    eventDate = Column(DateTime, nullable=True)
+    startTime = Column(String, nullable=False)
+    endTime = Column(String, nullable=False)
+    titel = Column(String, nullable=True)
+    description = Column(Text, nullable=False)
+    speaker = Column(String, nullable=False)
+    location = Column(String, nullable=False)
+    locationInfo = Column(String, nullable=True)
+    mapUrl = Column(String, nullable=True)
+    isFree = Column(Boolean, nullable=False)
+    price = Column(Integer, nullable=False)
+    isLimited = Column(Boolean, nullable=False)
+    stock = Column(Integer, nullable=False)
+    showBooked = Column(Boolean, nullable=False)
+    booked = Column(Integer, nullable=False)
+    dateBookingStart = Column(String, nullable=True)
+    dateBookingEnd = Column(String, nullable=True)
+    imageUrl150 = Column(String, nullable=True)
+    imageUrl300 = Column(String, nullable=True)
+    eventUrl = Column(String, nullable=False)
+
+    admins = relationship("ExternalEventAdminTable", back_populates="event", cascade="all, delete-orphan")
+    categories = relationship("ExternalEventCategoryTable", back_populates="event", cascade="all, delete-orphan")
+
+    def to_dict(self):
+        return {
+            "eventId": self.eventId,
+            "eventDate": self.eventDate,
+            "startTime": self.startTime,
+            "endTime": self.endTime,
+            "titel": self.titel,
+            "description": self.description,
+            "speaker": self.speaker,
+            "location": self.location,
+            "locationInfo": self.locationInfo,
+            "mapUrl": self.mapUrl,
+            "admins": [a.admin_id for a in self.admins] if self.admins else None,
+            "isFree": self.isFree,
+            "price": self.price,
+            "isLimited": self.isLimited,
+            "stock": self.stock,
+            "showBooked": self.showBooked,
+            "booked": self.booked,
+            "dateBookingStart": self.dateBookingStart,
+            "dateBookingEnd": self.dateBookingEnd,
+            "categories": [{"code": c.code, "text": c.text, "colorText": c.colorText, "colorBackground": c.colorBackground} for c in self.categories] if self.categories else None,
+            "imageUrl150": self.imageUrl150,
+            "imageUrl300": self.imageUrl300,
+            "eventUrl": self.eventUrl,
+        }
+
+
+class ExternalEventAdminTable(Base):
+    __tablename__ = "external_event_admins"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    eventId = Column(Integer, ForeignKey("external_event_details.eventId", ondelete="CASCADE"), nullable=False)
+    admin_id = Column(String, nullable=False)
+
+    event = relationship("ExternalEventDetailsTable", back_populates="admins")
+
+
+class ExternalEventCategoryTable(Base):
+    __tablename__ = "external_event_categories"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    eventId = Column(Integer, ForeignKey("external_event_details.eventId", ondelete="CASCADE"), nullable=False)
+    code = Column(String, nullable=False)
+    text = Column(String, nullable=False)
+    colorText = Column(String, nullable=False)
+    colorBackground = Column(String, nullable=False)
+
+    event = relationship("ExternalEventDetailsTable", back_populates="categories")
+
+
+# ── External Root ─────────────────────────────────────────────────────────────
+
+class ExternalRootTable(Base):
+    __tablename__ = "external_root"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    version = Column(Integer, nullable=False)
+    loginUrl = Column(String, nullable=False)
+    restUrl = Column(String, nullable=False)
+    siteUrl = Column(String, nullable=False)
+    header1 = Column(String, nullable=False)
+    header2 = Column(String, nullable=False)
+    city = Column(String, nullable=False)
+    streetAddress = Column(String, nullable=False)
+    mapUrl = Column(String, nullable=False)
+
+    dates = relationship("ExternalRootDateTable", back_populates="root", cascade="all, delete-orphan")
+
+    def to_dict(self):
+        return {
+            "version": self.version,
+            "loginUrl": self.loginUrl,
+            "restUrl": self.restUrl,
+            "siteUrl": self.siteUrl,
+            "dates": [d.date_value for d in self.dates],
+            "header1": self.header1,
+            "header2": self.header2,
+            "city": self.city,
+            "streetAddress": self.streetAddress,
+            "mapUrl": self.mapUrl,
+        }
+
+
+class ExternalRootDateTable(Base):
+    __tablename__ = "external_root_dates"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    root_id = Column(Integer, ForeignKey("external_root.id", ondelete="CASCADE"), nullable=False)
+    date_value = Column(String, nullable=False)
+
+    root = relationship("ExternalRootTable", back_populates="dates")
+
+
+class ExternalEventBookingTable(Base):
+    __tablename__ = "external_event_bookings"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    userId = Column(Integer, nullable=False, index=True)
+    eventId = Column(Integer, nullable=False, index=True)
+
+    __table_args__ = (
+        UniqueConstraint("userId", "eventId", name="uq_external_event_booking"),
+    )

--- a/backend/v1/db/tables.py
+++ b/backend/v1/db/tables.py
@@ -250,6 +250,10 @@ class EventHostTable(Base):
 
     event = relationship("UserEventTable", back_populates="hosts")
 
+    __table_args__ = (
+        UniqueConstraint("event_id", "userId", name="uq_event_host"),
+    )
+
 
 class EventSuggestedHostTable(Base):
     __tablename__ = "event_suggested_hosts"
@@ -259,6 +263,10 @@ class EventSuggestedHostTable(Base):
     userId = Column(Integer, nullable=False)
 
     event = relationship("UserEventTable", back_populates="suggested_hosts")
+
+    __table_args__ = (
+        UniqueConstraint("event_id", "userId", name="uq_event_suggested_host"),
+    )
 
 
 class EventAttendeeTable(Base):

--- a/backend/v1/db/tables.py
+++ b/backend/v1/db/tables.py
@@ -1,10 +1,16 @@
 """SQLAlchemy table definitions for all database models."""
 
+from datetime import datetime, timezone
 from sqlalchemy import (
-    Column, Integer, String, Boolean, Float, DateTime, Text, ForeignKey, JSON, UniqueConstraint
+    Column, Index, Integer, String, Boolean, Float,
+    DateTime, Text, ForeignKey, JSON, UniqueConstraint, CheckConstraint,
 )
 from sqlalchemy.orm import relationship
 from v1.db.database import Base
+
+
+def _now():
+    return datetime.now(timezone.utc)
 
 
 # ── User ──────────────────────────────────────────────────────────────────────
@@ -17,8 +23,19 @@ class UserTable(Base):
 
     # Settings (flattened from UserSettings)
     show_location = Column(String, default="NO_ONE", nullable=False)
-    show_email = Column(Boolean, default=False, nullable=False)
-    show_phone = Column(Boolean, default=False, nullable=False)
+    show_profile = Column(String, default="MEMBERS_MUTUAL", nullable=False)
+    show_email = Column(String, default="NO_ONE", nullable=False)
+    show_phone = Column(String, default="NO_ONE", nullable=False)
+    show_interests = Column(String, default="MEMBERS_MUTUAL", nullable=False)
+    show_hometown = Column(String, default="MEMBERS_MUTUAL", nullable=False)
+    show_birthdate = Column(String, default="MEMBERS_MUTUAL", nullable=False)
+    show_gender = Column(String, default="NO_ONE", nullable=False)
+    show_sexuality = Column(String, default="NO_ONE", nullable=False)
+    show_relationship_style = Column(String, default="NO_ONE", nullable=False)
+    show_relationship_status = Column(String, default="NO_ONE", nullable=False)
+    show_social_vibes = Column(String, default="MEMBERS_MUTUAL", nullable=False)
+    show_pronomen = Column(String, default="NO_ONE", nullable=False)
+    show_attendance = Column(String, default="MEMBERS_MUTUAL", nullable=True)
     location_update_interval_seconds = Column(Integer, default=60, nullable=False)
     events_refresh_interval_seconds = Column(Integer, default=60, nullable=False)
     background_location_updates = Column(Boolean, default=False, nullable=False)
@@ -26,7 +43,7 @@ class UserTable(Base):
     # Location (nullable)
     location_latitude = Column(Float, nullable=True)
     location_longitude = Column(Float, nullable=True)
-    location_timestamp = Column(DateTime, nullable=True)
+    location_timestamp = Column(DateTime(timezone=True), nullable=True)
     location_accuracy = Column(Float, nullable=True)
 
     # Contact info
@@ -39,19 +56,43 @@ class UserTable(Base):
     avatar_url = Column(String, nullable=True)
     firstName = Column(String, nullable=True)
     lastName = Column(String, nullable=True)
+    interests = Column(JSON, nullable=True, default=list)
+    hometown = Column(String, nullable=True)
+    birthdate = Column(String, nullable=True)
+    gender = Column(String, nullable=True)
+    sexuality = Column(String, nullable=True)
+    relationship_style = Column(String, nullable=True)
+    relationship_status = Column(String, nullable=True)
+    social_vibes = Column(JSON, nullable=True, default=list)
+    pronomen = Column(String, nullable=True)
+
+    # Audit
+    created_at = Column(DateTime(timezone=True), default=_now, nullable=False)
+    updated_at = Column(DateTime(timezone=True), default=_now, onupdate=_now, nullable=False)
 
     @classmethod
     def from_pydantic(cls, user):
-        """Create a UserTable row from a Pydantic User model."""
+        s = user.settings if user.settings else None
         return cls(
             userId=user.userId,
             isMember=user.isMember,
-            show_location=user.settings.show_location.value if user.settings else "NO_ONE",
-            show_email=user.settings.show_email if user.settings else False,
-            show_phone=user.settings.show_phone if user.settings else False,
-            location_update_interval_seconds=user.settings.location_update_interval_seconds if user.settings else 60,
-            events_refresh_interval_seconds=user.settings.events_refresh_interval_seconds if user.settings else 60,
-            background_location_updates=user.settings.background_location_updates if user.settings else False,
+            show_location=s.show_location.value if s else "NO_ONE",
+            show_profile=s.show_profile.value if s else "MEMBERS_MUTUAL",
+            show_email=s.show_email.value if s else "NO_ONE",
+            show_phone=s.show_phone.value if s else "NO_ONE",
+            show_interests=s.show_interests.value if s else "MEMBERS_MUTUAL",
+            show_hometown=s.show_hometown.value if s else "MEMBERS_MUTUAL",
+            show_birthdate=s.show_birthdate.value if s else "MEMBERS_MUTUAL",
+            show_gender=s.show_gender.value if s else "NO_ONE",
+            show_sexuality=s.show_sexuality.value if s else "NO_ONE",
+            show_relationship_style=s.show_relationship_style.value if s else "NO_ONE",
+            show_relationship_status=s.show_relationship_status.value if s else "NO_ONE",
+            show_social_vibes=s.show_social_vibes.value if s else "MEMBERS_MUTUAL",
+            show_pronomen=s.show_pronomen.value if s else "NO_ONE",
+            show_attendance=s.show_attendance.value if (s and s.show_attendance) else "MEMBERS_MUTUAL",
+            location_update_interval_seconds=s.location_update_interval_seconds if s else 60,
+            events_refresh_interval_seconds=s.events_refresh_interval_seconds if s else 60,
+            background_location_updates=s.background_location_updates if s else False,
             location_latitude=user.location.latitude if user.location else None,
             location_longitude=user.location.longitude if user.location else None,
             location_timestamp=user.location.timestamp if user.location else None,
@@ -63,17 +104,36 @@ class UserTable(Base):
             avatar_url=user.avatar_url,
             firstName=user.firstName,
             lastName=user.lastName,
+            interests=[i.value if hasattr(i, "value") else i for i in user.interests] if user.interests else [],
+            hometown=user.hometown,
+            birthdate=user.birthdate,
+            gender=user.gender,
+            sexuality=user.sexuality,
+            relationship_style=user.relationship_style,
+            relationship_status=user.relationship_status,
+            social_vibes=list(user.social_vibes) if user.social_vibes else [],
+            pronomen=user.pronomen,
         )
 
     def to_dict(self):
-        """Convert to a dict matching the Pydantic User model shape."""
         result = {
             "userId": self.userId,
             "isMember": self.isMember,
             "settings": {
                 "show_location": self.show_location,
+                "show_profile": self.show_profile,
                 "show_email": self.show_email,
                 "show_phone": self.show_phone,
+                "show_interests": self.show_interests,
+                "show_hometown": self.show_hometown,
+                "show_birthdate": self.show_birthdate,
+                "show_gender": self.show_gender,
+                "show_sexuality": self.show_sexuality,
+                "show_relationship_style": self.show_relationship_style,
+                "show_relationship_status": self.show_relationship_status,
+                "show_social_vibes": self.show_social_vibes,
+                "show_pronomen": self.show_pronomen,
+                "show_attendance": self.show_attendance,
                 "location_update_interval_seconds": self.location_update_interval_seconds,
                 "events_refresh_interval_seconds": self.events_refresh_interval_seconds,
                 "background_location_updates": self.background_location_updates,
@@ -83,6 +143,15 @@ class UserTable(Base):
             "avatar_url": self.avatar_url,
             "firstName": self.firstName,
             "lastName": self.lastName,
+            "interests": self.interests or [],
+            "hometown": self.hometown,
+            "birthdate": self.birthdate,
+            "gender": self.gender,
+            "sexuality": self.sexuality,
+            "relationship_style": self.relationship_style,
+            "relationship_status": self.relationship_status,
+            "social_vibes": self.social_vibes or [],
+            "pronomen": self.pronomen,
         }
         if self.location_latitude is not None:
             result["location"] = {
@@ -112,8 +181,8 @@ class TokenStorageTable(Base):
 
     userId = Column(Integer, primary_key=True)
     externalAccessToken = Column(String, nullable=False)
-    createdAt = Column(DateTime, nullable=False)
-    expiresAt = Column(DateTime, nullable=False)
+    createdAt = Column(DateTime(timezone=True), nullable=False)
+    expiresAt = Column(DateTime(timezone=True), nullable=False)
 
 
 # ── User Events ───────────────────────────────────────────────────────────────
@@ -122,10 +191,10 @@ class UserEventTable(Base):
     __tablename__ = "user_events"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
-    userId = Column(Integer, nullable=False)
+    userId = Column(Integer, nullable=False, index=True)
     name = Column(String, nullable=False)
-    start = Column(DateTime, nullable=False)
-    end = Column(DateTime, nullable=True)
+    start = Column(DateTime(timezone=True), nullable=False, index=True)
+    end = Column(DateTime(timezone=True), nullable=True)
     description = Column(Text, nullable=True)
     maxAttendees = Column(Integer, nullable=True)
 
@@ -136,6 +205,10 @@ class UserEventTable(Base):
     location_latitude = Column(Float, nullable=True)
     location_longitude = Column(Float, nullable=True)
 
+    # Audit
+    created_at = Column(DateTime(timezone=True), default=_now, nullable=False)
+    updated_at = Column(DateTime(timezone=True), default=_now, onupdate=_now, nullable=False)
+
     # Relationships
     hosts = relationship("EventHostTable", back_populates="event", cascade="all, delete-orphan")
     suggested_hosts = relationship("EventSuggestedHostTable", back_populates="event", cascade="all, delete-orphan")
@@ -143,7 +216,6 @@ class UserEventTable(Base):
     reports = relationship("EventReportTable", back_populates="event", cascade="all, delete-orphan")
 
     def to_dict(self):
-        """Convert to a dict matching the Pydantic UserEvent model shape."""
         location = None
         if any([self.location_description, self.location_address, self.location_latitude]):
             location = {
@@ -173,7 +245,7 @@ class EventHostTable(Base):
     __tablename__ = "event_hosts"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
-    event_id = Column(Integer, ForeignKey("user_events.id", ondelete="CASCADE"), nullable=False)
+    event_id = Column(Integer, ForeignKey("user_events.id", ondelete="CASCADE"), nullable=False, index=True)
     userId = Column(Integer, nullable=False)
 
     event = relationship("UserEventTable", back_populates="hosts")
@@ -183,7 +255,7 @@ class EventSuggestedHostTable(Base):
     __tablename__ = "event_suggested_hosts"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
-    event_id = Column(Integer, ForeignKey("user_events.id", ondelete="CASCADE"), nullable=False)
+    event_id = Column(Integer, ForeignKey("user_events.id", ondelete="CASCADE"), nullable=False, index=True)
     userId = Column(Integer, nullable=False)
 
     event = relationship("UserEventTable", back_populates="suggested_hosts")
@@ -193,17 +265,21 @@ class EventAttendeeTable(Base):
     __tablename__ = "event_attendees"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
-    event_id = Column(Integer, ForeignKey("user_events.id", ondelete="CASCADE"), nullable=False)
+    event_id = Column(Integer, ForeignKey("user_events.id", ondelete="CASCADE"), nullable=False, index=True)
     userId = Column(Integer, nullable=False)
 
     event = relationship("UserEventTable", back_populates="attendees")
+
+    __table_args__ = (
+        UniqueConstraint("event_id", "userId", name="uq_event_attendee"),
+    )
 
 
 class EventReportTable(Base):
     __tablename__ = "event_reports"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
-    event_id = Column(Integer, ForeignKey("user_events.id", ondelete="CASCADE"), nullable=False)
+    event_id = Column(Integer, ForeignKey("user_events.id", ondelete="CASCADE"), nullable=False, index=True)
     userId = Column(Integer, nullable=False)
     text = Column(Text, nullable=False)
 
@@ -216,7 +292,7 @@ class ExternalEventDetailsTable(Base):
     __tablename__ = "external_event_details"
 
     eventId = Column(Integer, primary_key=True)
-    eventDate = Column(DateTime, nullable=True)
+    eventDate = Column(DateTime(timezone=True), nullable=True)
     startTime = Column(String, nullable=False)
     endTime = Column(String, nullable=False)
     titel = Column(String, nullable=True)
@@ -236,6 +312,10 @@ class ExternalEventDetailsTable(Base):
     imageUrl150 = Column(String, nullable=True)
     imageUrl300 = Column(String, nullable=True)
     eventUrl = Column(String, nullable=False)
+
+    # Audit
+    created_at = Column(DateTime(timezone=True), default=_now, nullable=False)
+    updated_at = Column(DateTime(timezone=True), default=_now, onupdate=_now, nullable=False)
 
     admins = relationship("ExternalEventAdminTable", back_populates="event", cascade="all, delete-orphan")
     categories = relationship("ExternalEventCategoryTable", back_populates="event", cascade="all, delete-orphan")
@@ -272,7 +352,7 @@ class ExternalEventAdminTable(Base):
     __tablename__ = "external_event_admins"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
-    eventId = Column(Integer, ForeignKey("external_event_details.eventId", ondelete="CASCADE"), nullable=False)
+    eventId = Column(Integer, ForeignKey("external_event_details.eventId", ondelete="CASCADE"), nullable=False, index=True)
     admin_id = Column(String, nullable=False)
 
     event = relationship("ExternalEventDetailsTable", back_populates="admins")
@@ -282,7 +362,7 @@ class ExternalEventCategoryTable(Base):
     __tablename__ = "external_event_categories"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
-    eventId = Column(Integer, ForeignKey("external_event_details.eventId", ondelete="CASCADE"), nullable=False)
+    eventId = Column(Integer, ForeignKey("external_event_details.eventId", ondelete="CASCADE"), nullable=False, index=True)
     code = Column(String, nullable=False)
     text = Column(String, nullable=False)
     colorText = Column(String, nullable=False)
@@ -294,9 +374,10 @@ class ExternalEventCategoryTable(Base):
 # ── External Root ─────────────────────────────────────────────────────────────
 
 class ExternalRootTable(Base):
+    """Singleton table — at most one row enforced by a CHECK constraint on id."""
     __tablename__ = "external_root"
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
+    id = Column(Integer, primary_key=True, default=1)
     version = Column(Integer, nullable=False)
     loginUrl = Column(String, nullable=False)
     restUrl = Column(String, nullable=False)
@@ -307,7 +388,15 @@ class ExternalRootTable(Base):
     streetAddress = Column(String, nullable=False)
     mapUrl = Column(String, nullable=False)
 
+    # Audit
+    created_at = Column(DateTime(timezone=True), default=_now, nullable=False)
+    updated_at = Column(DateTime(timezone=True), default=_now, onupdate=_now, nullable=False)
+
     dates = relationship("ExternalRootDateTable", back_populates="root", cascade="all, delete-orphan")
+
+    __table_args__ = (
+        CheckConstraint("id = 1", name="ck_external_root_singleton"),
+    )
 
     def to_dict(self):
         return {
@@ -344,3 +433,30 @@ class ExternalEventBookingTable(Base):
     __table_args__ = (
         UniqueConstraint("userId", "eventId", name="uq_external_event_booking"),
     )
+
+
+# ── Feedback ──────────────────────────────────────────────────────────────────
+
+class FeedbackVoteTable(Base):
+    __tablename__ = "feedback_votes"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    issue_number = Column(Integer, nullable=False, index=True)
+    user_hash = Column(String, nullable=False)
+    value = Column(Integer, nullable=False)
+
+    __table_args__ = (
+        UniqueConstraint("issue_number", "user_hash", name="uq_feedback_vote"),
+    )
+
+
+class FeedbackUserIndexTable(Base):
+    __tablename__ = "feedback_user_index"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    user_hash = Column(String, nullable=False, unique=True, index=True)
+    user_id = Column(Integer, nullable=True, index=True)
+    member_number = Column(String, nullable=True)
+    is_member = Column(Boolean, nullable=False, default=False)
+    first_seen = Column(DateTime(timezone=True), nullable=False)
+    last_seen = Column(DateTime(timezone=True), nullable=False)

--- a/backend/v1/db/users.py
+++ b/backend/v1/db/users.py
@@ -2,7 +2,7 @@ import json
 from typing import Optional
 from pydantic import ValidationError
 from v1.db.models.user import ContactInfo, ShowLocation, User, UserSettings
-from v1.db.database import SessionLocal
+from v1.db.database import get_session
 from v1.db.tables import UserTable
 
 
@@ -13,7 +13,7 @@ def get_user(user_id: int) -> dict | None:
     :param user_id: The user ID.
     :return: The user dict or None.
     """
-    with SessionLocal() as session:
+    with get_session() as session:
         row = session.query(UserTable).filter_by(userId=user_id).first()
         return row.to_dict() if row else None
 
@@ -26,7 +26,7 @@ def update_user(user_id: int, user: dict) -> dict:
     :param user: The user data as a dict.
     :return: The user data.
     """
-    with SessionLocal() as session:
+    with get_session() as session:
         row = session.query(UserTable).filter_by(userId=user_id).first()
         if not row:
             return user
@@ -87,7 +87,7 @@ def create_user(response_json: dict) -> dict | None:
         return None
 
     user_model = User(**newuser) if isinstance(newuser, dict) else newuser
-    with SessionLocal() as session:
+    with get_session() as session:
         row = UserTable.from_pydantic(user_model)
         session.add(row)
         session.commit()
@@ -101,7 +101,7 @@ def get_users(show_location: Optional[bool] = None) -> list[dict]:
     :param show_location: If True, filter to users who share their location.
     :return: List of user dicts.
     """
-    with SessionLocal() as session:
+    with get_session() as session:
         query = session.query(UserTable)
         if show_location is not None:
             query = query.filter(UserTable.show_location != ShowLocation.NO_ONE.value)
@@ -123,7 +123,7 @@ def get_users_showing_location() -> list[dict]:
 
     :return: List of user dicts.
     """
-    with SessionLocal() as session:
+    with get_session() as session:
         rows = session.query(UserTable).filter(
             UserTable.show_location != ShowLocation.NO_ONE.value
         ).all()

--- a/backend/v1/db/users.py
+++ b/backend/v1/db/users.py
@@ -112,7 +112,7 @@ def get_users(show_location: Optional[bool] = None) -> list[dict]:
 def get_users_by_ids(user_ids: list[int]) -> list[dict]:
     if not user_ids:
         return []
-    with SessionLocal() as session:
+    with get_session() as session:
         rows = session.query(UserTable).filter(UserTable.userId.in_(user_ids)).all()
         return [row.to_dict() for row in rows]
 
@@ -131,7 +131,7 @@ def get_users_showing_location() -> list[dict]:
 
 
 def update_user_from_authresponse(user_id: int, response_json: dict) -> None:
-    with SessionLocal() as session:
+    with get_session() as session:
         row = session.query(UserTable).filter_by(userId=user_id).first()
         if not row:
             return

--- a/backend/v1/db/users.py
+++ b/backend/v1/db/users.py
@@ -1,86 +1,148 @@
 import json
 from typing import Optional
 from pydantic import ValidationError
-from v1.db.models.user import ContactInfo, PrivacySetting, User, UserSettings
-from v1.db.mongo import user_collection
+from v1.db.models.user import ContactInfo, ShowLocation, User, UserSettings
+from v1.db.database import SessionLocal
+from v1.db.tables import UserTable
 
 
-def get_user(user_id: int) -> User:
+def get_user(user_id: int) -> dict | None:
     """
-    Retrieves a user document from the MongoDB database.
+    Retrieves a user from the database.
 
     :param user_id: The user ID.
-    :param db: The MongoDB database object.
-    :return: The user document.
+    :return: The user dict or None.
     """
+    with SessionLocal() as session:
+        row = session.query(UserTable).filter_by(userId=user_id).first()
+        return row.to_dict() if row else None
 
-    return user_collection.find_one({"userId": user_id})
 
-
-def update_user(user_id: int, user: User) -> User:
+def update_user(user_id: int, user: dict) -> dict:
     """
-    Updates a user document in the MongoDB database.
+    Updates a user in the database.
 
     :param user_id: The user ID.
-    :param user: The user document.
-    :param db: The MongoDB database object.
-    :return: The user document.
+    :param user: The user data as a dict.
+    :return: The user data.
     """
-    user_collection.update_one({"userId": user_id}, {"$set": user})
+    with SessionLocal() as session:
+        row = session.query(UserTable).filter_by(userId=user_id).first()
+        if not row:
+            return user
+
+        # Flatten nested dicts for column assignment
+        if isinstance(user, dict):
+            data = user
+        else:
+            data = user if isinstance(user, dict) else dict(user)
+
+        # Top-level fields
+        for key in ("isMember", "age", "slogan", "avatar_url", "firstName", "lastName"):
+            if key in data:
+                setattr(row, key, data[key])
+
+        # Settings
+        settings = data.get("settings")
+        if settings:
+            row.show_location = settings.get("show_location", row.show_location)
+            row.show_email = settings.get("show_email", row.show_email)
+            row.show_phone = settings.get("show_phone", row.show_phone)
+            row.location_update_interval_seconds = settings.get("location_update_interval_seconds", row.location_update_interval_seconds)
+            row.events_refresh_interval_seconds = settings.get("events_refresh_interval_seconds", row.events_refresh_interval_seconds)
+            row.background_location_updates = settings.get("background_location_updates", row.background_location_updates)
+
+        # Location
+        location = data.get("location")
+        if location is not None:
+            row.location_latitude = location.get("latitude")
+            row.location_longitude = location.get("longitude")
+            row.location_timestamp = location.get("timestamp")
+            row.location_accuracy = location.get("accuracy")
+        elif "location" in data and data["location"] is None:
+            row.location_latitude = None
+            row.location_longitude = None
+            row.location_timestamp = None
+            row.location_accuracy = None
+
+        # Contact info
+        contact = data.get("contact_info")
+        if contact is not None:
+            row.contact_email = contact.get("email")
+            row.contact_phone = contact.get("phone")
+
+        session.commit()
     return user
 
 
-def create_user(response_json: dict) -> User:
+def create_user(response_json: dict) -> dict | None:
     """
-    Creates a new user document in the MongoDB database
+    Creates a new user in the database.
 
-    :param user: The user document.
-    :param db: The MongoDB database object.
-    :return: The user document.
+    :param response_json: The auth response JSON.
+    :return: The user dict.
     """
     newuser = map_authresponse_to_user(response_json)
-    user_collection.insert_one(newuser)
+    if newuser is None:
+        return None
+
+    user_model = User(**newuser) if isinstance(newuser, dict) else newuser
+    with SessionLocal() as session:
+        row = UserTable.from_pydantic(user_model)
+        session.add(row)
+        session.commit()
     return newuser
 
 
-def get_users(show_location: Optional[bool] = None) -> list[User]:
+def get_users(show_location: Optional[bool] = None) -> list[dict]:
     """
-    Retrieves all user documents from the MongoDB database.
+    Retrieves all users from the database.
 
-    :param show_location: The show_location flag to filter users by.
-    :return: The user documents.
+    :param show_location: If True, filter to users who share their location.
+    :return: List of user dicts.
     """
-    query = {}
-    if show_location is not None:
-        query = {'settings.show_location': {'$ne': PrivacySetting.NO_ONE.value}}
-    return list(user_collection.find(query))
+    with SessionLocal() as session:
+        query = session.query(UserTable)
+        if show_location is not None:
+            query = query.filter(UserTable.show_location != ShowLocation.NO_ONE.value)
+        rows = query.all()
+        return [row.to_dict() for row in rows]
 
 
 def get_users_by_ids(user_ids: list[int]) -> list[dict]:
-    return list(user_collection.find({"userId": {"$in": user_ids}}))
+    if not user_ids:
+        return []
+    with SessionLocal() as session:
+        rows = session.query(UserTable).filter(UserTable.userId.in_(user_ids)).all()
+        return [row.to_dict() for row in rows]
 
 
-def get_users_showing_location() -> list[User]:
+def get_users_showing_location() -> list[dict]:
     """
-    Retrieves all user documents from the MongoDB database where ShowLocation is not no_one.
+    Retrieves all users who share their location.
 
-    :return: The user documents.
+    :return: List of user dicts.
     """
-    query = {"settings.show_location": {"$ne": PrivacySetting.NO_ONE.value}}
-    return list(user_collection.find(query))
+    with SessionLocal() as session:
+        rows = session.query(UserTable).filter(
+            UserTable.show_location != ShowLocation.NO_ONE.value
+        ).all()
+        return [row.to_dict() for row in rows]
 
 
 def update_user_from_authresponse(user_id: int, response_json: dict) -> None:
-    updates = {
-        "firstName": response_json.get("firstName"),
-        "lastName": response_json.get("lastName"),
-        "contact_info.email": response_json.get("email"),
-        "isMember": response_json.get("type") == "M",
-    }
-    user_collection.update_one({"userId": user_id}, {"$set": updates})
+    with SessionLocal() as session:
+        row = session.query(UserTable).filter_by(userId=user_id).first()
+        if not row:
+            return
+        row.firstName = response_json.get("firstName", row.firstName)
+        row.lastName = response_json.get("lastName", row.lastName)
+        row.contact_email = response_json.get("email", row.contact_email)
+        row.isMember = response_json.get("type") == "M"
+        session.commit()
 
 
-def map_authresponse_to_user(response_json: dict) -> User:
+def map_authresponse_to_user(response_json: dict) -> dict | None:
     user = User(
         userId=response_json["memberId"],
         isMember=response_json["type"] == "M",

--- a/backend/v1/db/users.py
+++ b/backend/v1/db/users.py
@@ -1,58 +1,52 @@
 import json
 from typing import Optional
 from pydantic import ValidationError
-from v1.db.models.user import ContactInfo, ShowLocation, User, UserSettings
+from v1.db.models.user import ContactInfo, PrivacySetting, User, UserSettings
 from v1.db.database import get_session
 from v1.db.tables import UserTable
 
 
 def get_user(user_id: int) -> dict | None:
-    """
-    Retrieves a user from the database.
-
-    :param user_id: The user ID.
-    :return: The user dict or None.
-    """
     with get_session() as session:
         row = session.query(UserTable).filter_by(userId=user_id).first()
         return row.to_dict() if row else None
 
 
 def update_user(user_id: int, user: dict) -> dict:
-    """
-    Updates a user in the database.
-
-    :param user_id: The user ID.
-    :param user: The user data as a dict.
-    :return: The user data.
-    """
     with get_session() as session:
         row = session.query(UserTable).filter_by(userId=user_id).first()
         if not row:
             return user
 
-        # Flatten nested dicts for column assignment
-        if isinstance(user, dict):
-            data = user
-        else:
-            data = user if isinstance(user, dict) else dict(user)
+        data = user if isinstance(user, dict) else dict(user)
 
-        # Top-level fields
-        for key in ("isMember", "age", "slogan", "avatar_url", "firstName", "lastName"):
+        for key in ("isMember", "age", "slogan", "avatar_url", "firstName", "lastName",
+                    "interests", "hometown", "birthdate", "gender", "sexuality",
+                    "relationship_style", "relationship_status", "social_vibes", "pronomen"):
             if key in data:
-                setattr(row, key, data[key])
+                val = data[key]
+                if key == "interests" and val is not None:
+                    val = [i.value if hasattr(i, "value") else i for i in val]
+                setattr(row, key, val)
 
-        # Settings
         settings = data.get("settings")
         if settings:
-            row.show_location = settings.get("show_location", row.show_location)
-            row.show_email = settings.get("show_email", row.show_email)
-            row.show_phone = settings.get("show_phone", row.show_phone)
-            row.location_update_interval_seconds = settings.get("location_update_interval_seconds", row.location_update_interval_seconds)
-            row.events_refresh_interval_seconds = settings.get("events_refresh_interval_seconds", row.events_refresh_interval_seconds)
-            row.background_location_updates = settings.get("background_location_updates", row.background_location_updates)
+            _bool_privacy_fields = {"show_email", "show_phone"}
+            for field in ("show_location", "show_profile", "show_email", "show_phone",
+                          "show_interests", "show_hometown", "show_birthdate", "show_gender",
+                          "show_sexuality", "show_relationship_style", "show_relationship_status",
+                          "show_social_vibes", "show_pronomen", "show_attendance",
+                          "location_update_interval_seconds", "events_refresh_interval_seconds",
+                          "background_location_updates"):
+                if field in settings:
+                    val = settings[field]
+                    if hasattr(val, "value"):
+                        val = val.value
+                    # Coerce legacy boolean values for privacy fields
+                    if field in _bool_privacy_fields and isinstance(val, bool):
+                        val = "MEMBERS_ONLY" if val else "NO_ONE"
+                    setattr(row, field, val)
 
-        # Location
         location = data.get("location")
         if location is not None:
             row.location_latitude = location.get("latitude")
@@ -65,7 +59,6 @@ def update_user(user_id: int, user: dict) -> dict:
             row.location_timestamp = None
             row.location_accuracy = None
 
-        # Contact info
         contact = data.get("contact_info")
         if contact is not None:
             row.contact_email = contact.get("email")
@@ -76,12 +69,6 @@ def update_user(user_id: int, user: dict) -> dict:
 
 
 def create_user(response_json: dict) -> dict | None:
-    """
-    Creates a new user in the database.
-
-    :param response_json: The auth response JSON.
-    :return: The user dict.
-    """
     newuser = map_authresponse_to_user(response_json)
     if newuser is None:
         return None
@@ -95,16 +82,10 @@ def create_user(response_json: dict) -> dict | None:
 
 
 def get_users(show_location: Optional[bool] = None) -> list[dict]:
-    """
-    Retrieves all users from the database.
-
-    :param show_location: If True, filter to users who share their location.
-    :return: List of user dicts.
-    """
     with get_session() as session:
         query = session.query(UserTable)
         if show_location is not None:
-            query = query.filter(UserTable.show_location != ShowLocation.NO_ONE.value)
+            query = query.filter(UserTable.show_location != PrivacySetting.NO_ONE.value)
         rows = query.all()
         return [row.to_dict() for row in rows]
 
@@ -118,14 +99,9 @@ def get_users_by_ids(user_ids: list[int]) -> list[dict]:
 
 
 def get_users_showing_location() -> list[dict]:
-    """
-    Retrieves all users who share their location.
-
-    :return: List of user dicts.
-    """
     with get_session() as session:
         rows = session.query(UserTable).filter(
-            UserTable.show_location != ShowLocation.NO_ONE.value
+            UserTable.show_location != PrivacySetting.NO_ONE.value
         ).all()
         return [row.to_dict() for row in rows]
 
@@ -138,21 +114,22 @@ def update_user_from_authresponse(user_id: int, response_json: dict) -> None:
         row.firstName = response_json.get("firstName", row.firstName)
         row.lastName = response_json.get("lastName", row.lastName)
         row.contact_email = response_json.get("email", row.contact_email)
-        row.isMember = response_json.get("type") == "M"
+        # Only set isMember if 'type' key is present; absent key must not demote
+        if "type" in response_json:
+            row.isMember = response_json["type"] == "M"
         session.commit()
 
 
 def map_authresponse_to_user(response_json: dict) -> dict | None:
     user = User(
         userId=response_json["memberId"],
-        isMember=response_json["type"] == "M",
-        settings=UserSettings(),  # Default values
+        isMember=response_json.get("type") == "M",
+        settings=UserSettings(),
     )
 
     user.firstName = response_json.get("firstName", None)
     user.lastName = response_json.get("lastName", None)
-    user.contact_info = ContactInfo(email=response_json.get("email", None),
-                                    phone=None)  # Update email
+    user.contact_info = ContactInfo(email=response_json.get("email", None), phone=None)
 
     try:
         user_json = json.dumps(user.model_dump())

--- a/backend/v1/dev/user_events_dev_api.py
+++ b/backend/v1/dev/user_events_dev_api.py
@@ -2,9 +2,10 @@ import datetime
 import os
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
-from v1.db.mongo import user_collection, user_event_collection
-from v1.user_events.user_events_model import ExtendedUserEvent
-from v1.user_events.user_events_db import get_safe_user_event
+from v1.db.database import SessionLocal
+from v1.db.tables import UserTable, UserEventTable
+from v1.user_events.user_events_model import ExtendedUserEvent, UserEvent
+from v1.user_events.user_events_db import get_safe_user_event, create_user_event
 from v1.utilities import get_current_time
 
 
@@ -15,79 +16,92 @@ class StatusResponseWithMessage(BaseModel):
 dev_user_events = APIRouter(prefix="/v1")
 
 
+def _ensure_dummy_user(session):
+    """Ensure the dummy user exists."""
+    existing = session.query(UserTable).filter_by(userId=1337).first()
+    if not existing:
+        session.add(UserTable(
+            userId=1337,
+            isMember=False,
+            firstName="Dummy",
+            lastName="User",
+            contact_email="dummy@user.com",
+            show_location="NO_ONE",
+            show_email=False,
+            show_phone=False,
+            location_update_interval_seconds=60,
+            events_refresh_interval_seconds=60,
+            background_location_updates=False,
+        ))
+    else:
+        existing.firstName = "Dummy"
+        existing.lastName = "User"
+        existing.contact_email = "dummy@user.com"
+    session.commit()
+
+
 @dev_user_events.get("/dev/clear_user_events",
                      response_model=StatusResponseWithMessage)
 async def clear_user_events():
-    user_event_collection.delete_many({})
+    with SessionLocal() as session:
+        session.query(UserEventTable).delete()
+        session.commit()
     return {"message": "User events cleared"}
 
 
 @dev_user_events.get("/dev/create_dummy_user_event",
                      response_model=ExtendedUserEvent)
 async def get_dummy_user_event():
-    # Generate dummy user event
-    dummy_user = {
-        'userId': 1337,
-        'firstName': "Dummy",
-        'lastName': "User",
-        'email': "dummy@user.com",
-    }
-    user_collection.update_one({"userId": dummy_user['userId']},
-                               {"$set": dummy_user},
-                               upsert=True)
-    dummy_event = {
-        'userId': 1337,
-        'name': "Dummy Event",
-        'description': "This is a dummy event",
-        'start': get_current_time().replace(tzinfo=None) + datetime.timedelta(hours=20),
-        'end': get_current_time().replace(tzinfo=None) + datetime.timedelta(hours=25),
-        'maxAttendees': 10,
-    }
-    result = user_event_collection.insert_one(dummy_event)
+    with SessionLocal() as session:
+        _ensure_dummy_user(session)
 
-    event = get_safe_user_event(str(result.inserted_id))
+    dummy_event = UserEvent(
+        userId=1337,
+        name="Dummy Event",
+        description="This is a dummy event",
+        start=get_current_time().replace(tzinfo=None) + datetime.timedelta(hours=20),
+        end=get_current_time().replace(tzinfo=None) + datetime.timedelta(hours=25),
+        maxAttendees=10,
+        hosts=[],
+        suggested_hosts=[],
+        attendees=[],
+        reports=[],
+    )
+    event_id = create_user_event(dummy_event)
+
+    event = get_safe_user_event(str(event_id))
     if not event:
         raise HTTPException(status_code=404,
                             detail="Event not created. Insert ID: " +
-                            str(result.inserted_id))
+                            str(event_id))
     return event
 
 
 @dev_user_events.get("/dev/create_my_dummy_event",
                      response_model=ExtendedUserEvent)
 async def create_my_dummy_event():
+    with SessionLocal() as session:
+        _ensure_dummy_user(session)
 
-    dummy_user = {
-        'userId': 1337,
-        'firstName': "Dummy",
-        'lastName': "User",
-        'email': "dummy@user.com",
-    }
-    user_collection.update_one({"userId": dummy_user['userId']},
-                               {"$set": dummy_user},
-                               upsert=True)
+    userId = int(os.getenv('MY_USER_ID'))
 
-    userId = os.getenv('MY_USER_ID')
+    dummy_event = UserEvent(
+        userId=userId,
+        name="My Dummy Event",
+        description="This is a dummy event for the dev running the server (you)",
+        start=get_current_time().replace(tzinfo=None) + datetime.timedelta(hours=20),
+        end=get_current_time().replace(tzinfo=None) + datetime.timedelta(hours=25),
+        maxAttendees=10,
+        hosts=[],
+        suggested_hosts=[],
+        attendees=[{"userId": 1337}],
+        reports=[],
+    )
+    event_id = create_user_event(dummy_event)
 
-    dummy_event = {
-        'userId': userId,
-        'name': "My Dummy Event",
-        'description':
-        "This is a dummy event for the dev running the server (you)",
-        'start': get_current_time().replace(tzinfo=None) + datetime.timedelta(hours=20),
-        'end': get_current_time().replace(tzinfo=None) + datetime.timedelta(hours=25),
-        'maxAttendees': 10,
-        'attendees': [{
-            'userId': 1337
-        }]
-    }
-    result = user_event_collection.insert_one(dummy_event)
-
-    event = get_safe_user_event(str(result.inserted_id))
-
+    event = get_safe_user_event(str(event_id))
     if not event:
         raise HTTPException(status_code=404,
                             detail="Event not created. Insert ID: " +
-                            str(result.inserted_id))
-
+                            str(event_id))
     return event

--- a/backend/v1/dev/user_events_dev_api.py
+++ b/backend/v1/dev/user_events_dev_api.py
@@ -2,7 +2,7 @@ import datetime
 import os
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
-from v1.db.database import SessionLocal
+from v1.db.database import get_session
 from v1.db.tables import UserTable, UserEventTable
 from v1.user_events.user_events_model import ExtendedUserEvent, UserEvent
 from v1.user_events.user_events_db import get_safe_user_event, create_user_event
@@ -43,7 +43,7 @@ def _ensure_dummy_user(session):
 @dev_user_events.get("/dev/clear_user_events",
                      response_model=StatusResponseWithMessage)
 async def clear_user_events():
-    with SessionLocal() as session:
+    with get_session() as session:
         session.query(UserEventTable).delete()
         session.commit()
     return {"message": "User events cleared"}
@@ -52,7 +52,7 @@ async def clear_user_events():
 @dev_user_events.get("/dev/create_dummy_user_event",
                      response_model=ExtendedUserEvent)
 async def get_dummy_user_event():
-    with SessionLocal() as session:
+    with get_session() as session:
         _ensure_dummy_user(session)
 
     dummy_event = UserEvent(
@@ -80,7 +80,7 @@ async def get_dummy_user_event():
 @dev_user_events.get("/dev/create_my_dummy_event",
                      response_model=ExtendedUserEvent)
 async def create_my_dummy_event():
-    with SessionLocal() as session:
+    with get_session() as session:
         _ensure_dummy_user(session)
 
     userId = int(os.getenv('MY_USER_ID'))

--- a/backend/v1/events/events_service.py
+++ b/backend/v1/events/events_service.py
@@ -163,11 +163,11 @@ def create_user_event_via_unified(event: Event, current_user: dict) -> Event:
 def update_user_event_via_unified(unified_event_id: str, event: Event, current_user: dict) -> Event:
     if event.official:
         raise HTTPException(status_code=400, detail="Cannot update official events via this endpoint")
-    # Expect unified id like usr<mongoId>
+    # Expect unified id like usr<id>
     if not unified_event_id.startswith("usr"):
         raise HTTPException(status_code=400, detail="Only user events can be updated here")
     event_id = unified_event_id[3:]  # Remove 'usr' prefix
-    
+
     existing = db_get_safe_user_event(event_id)
     if not existing:
         raise HTTPException(status_code=404, detail="Event not found")
@@ -184,7 +184,7 @@ def update_user_event_via_unified(unified_event_id: str, event: Event, current_u
 
 
 def delete_user_event_via_unified(unified_event_id: str, current_user: dict) -> dict:
-    # Expect unified id like usr<mongoId>
+    # Expect unified id like usr<id>
     if not unified_event_id.startswith("usr"):
         raise HTTPException(status_code=400, detail="Only user events can be deleted here")
     event_id = unified_event_id[3:]  # Remove 'usr' prefix
@@ -219,11 +219,6 @@ def _attend_user_event(unified_event_id: str, current_user: dict) -> Event:
     """Attend a user event (internal implementation)."""
     event_id = unified_event_id[3:]  # Remove 'usr' prefix
     logging.info(f"Extracted user event_id: {event_id}, length: {len(event_id)}")
-    
-    # Validate the event ID format
-    if len(event_id) != 24:
-        logging.error(f"Invalid event ID length: {len(event_id)}, expected 24")
-        raise HTTPException(status_code=400, detail=f"Invalid event ID format: expected 24 characters, got {len(event_id)}")
     
     existing = db_get_safe_user_event(event_id)
     if not existing:

--- a/backend/v1/jobs/refresh_events.py
+++ b/backend/v1/jobs/refresh_events.py
@@ -54,7 +54,8 @@ def refresh_external_bookings():
     for user_id in user_ids:
         try:
             booked = get_booked_external_events(user_id)
-            event_ids = [e.eventId for e in booked]
-            upsert_user_bookings(userId=user_id, event_ids=event_ids)
         except Exception as e:
             logging.warning(f"[refresh_external_bookings] Skipping userId={user_id}: {e}")
+            continue
+        event_ids = [e.eventId for e in booked]
+        upsert_user_bookings(userId=user_id, event_ids=event_ids)

--- a/backend/v1/jobs/refresh_events.py
+++ b/backend/v1/jobs/refresh_events.py
@@ -8,7 +8,7 @@ from v1.external.event_api import (
     get_booked_external_events,
 )
 from v1.db.external_bookings import upsert_user_bookings
-from v1.db.database import SessionLocal
+from v1.db.database import get_session
 from v1.db.tables import TokenStorageTable
 import logging
 
@@ -44,7 +44,7 @@ def refresh_external_events():
 def refresh_external_bookings():
     """Refresh the external_event_bookings collection for all users with stored tokens."""
     try:
-        with SessionLocal() as session:
+        with get_session() as session:
             user_ids = [row.userId for row in session.query(TokenStorageTable.userId).all()]
     except Exception as e:
         logging.error(f"[refresh_external_bookings] Failed to fetch token holders: {e}")

--- a/backend/v1/jobs/refresh_events.py
+++ b/backend/v1/jobs/refresh_events.py
@@ -7,8 +7,9 @@ from v1.external.event_api import (
     get_external_event_details,
     get_booked_external_events,
 )
-from v1.db.external_bookings import upsert_user_bookings, delete_user_bookings
-from v1.db.mongo import tokenstorage_collection
+from v1.db.external_bookings import upsert_user_bookings
+from v1.db.database import SessionLocal
+from v1.db.tables import TokenStorageTable
 import logging
 
 def refresh_external_events():
@@ -43,7 +44,8 @@ def refresh_external_events():
 def refresh_external_bookings():
     """Refresh the external_event_bookings collection for all users with stored tokens."""
     try:
-        user_ids = [doc["userId"] for doc in tokenstorage_collection.find({}, {"userId": 1})]
+        with SessionLocal() as session:
+            user_ids = [row.userId for row in session.query(TokenStorageTable.userId).all()]
     except Exception as e:
         logging.error(f"[refresh_external_bookings] Failed to fetch token holders: {e}")
         return

--- a/backend/v1/requirements.txt
+++ b/backend/v1/requirements.txt
@@ -10,6 +10,7 @@ fastapi-health # Health checks for FastAPI
 python-multipart # Multipart form data
 uvicorn # ASGI server for FastAPI
 sqlalchemy # ORM for databases
+alembic # Database migrations
 faker # Fake data generator
 googlemaps # Google Maps API
 apscheduler # Scheduling periodic tasks

--- a/backend/v1/requirements.txt
+++ b/backend/v1/requirements.txt
@@ -1,4 +1,4 @@
-pymongo # MongoDB driver
+psycopg2-binary # PostgreSQL driver
 requests # HTTP requests
 PyJWT # JWT tokens
 pytest # Testing

--- a/backend/v1/server.py
+++ b/backend/v1/server.py
@@ -2,8 +2,6 @@ import datetime
 import logging
 import os
 from fastapi.staticfiles import StaticFiles
-from pydantic.v1.json import ENCODERS_BY_TYPE
-from bson import ObjectId
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 import datetime
@@ -23,8 +21,7 @@ from v1.external.event_site_news import get_event_site_news
 from v1.external.event_api import get_external_root, get_external_event_details
 from v1.db.external_events import clean_external_events, get_stored_external_event_details
 from v1.user_events.user_events_api import user_events_v1
-from v1.db.mongo import initialize_db
-from migrations.rename_privacy_settings import run as run_migrations
+from v1.db.database import initialize_db
 from v1.dev.exception_handlers import register_exception_handlers
 from v1.update_check_middleware import UpdateCheckMiddleware
 from v1.utilities import get_current_time_formatted
@@ -32,10 +29,6 @@ from v1.utilities import get_current_time_formatted
 # Initialize logging
 logging.basicConfig(level=logging.INFO)
 logging.info(f"Server started at {get_current_time_formatted()}")
-
-# Configure pydantic to automatically convert MongoDB ObjectId to string so we
-# don't have to manually create ID indices with autoincrementing integers
-ENCODERS_BY_TYPE[ObjectId] = str
 
 app = FastAPI()
 app.add_middleware(
@@ -75,12 +68,6 @@ if os.getenv("ENABLE_DEV_ENDPOINTS") == "true":
 
 def initialize_app():
     initialize_db()
-    run_migrations()
-
-    from v1.db.feedback_votes import initialize_indexes as init_feedback_votes
-    init_feedback_votes()
-    from v1.db.feedback_user_index import initialize_indexes as init_feedback_user_index
-    init_feedback_user_index()
 
     scheduler = create_scheduler()
     scheduler.start()

--- a/backend/v1/shared/model_with_id.py
+++ b/backend/v1/shared/model_with_id.py
@@ -1,24 +1,18 @@
 from datetime import datetime
-from typing import Annotated, Optional
-from pydantic import BeforeValidator, ConfigDict, BaseModel, Field
-from bson import ObjectId
+from typing import Optional
+from pydantic import ConfigDict, BaseModel, Field
 
 from v1.utilities import convert_to_tz_aware
 
-PyObjectId = Annotated[str, BeforeValidator(str)]
-
 
 class ModelWithId(BaseModel):
-    id: Optional[PyObjectId] = Field(alias="_id",
-                                     default=None,
-                                     example='507f191e810c19729de860ea',
-                                     serialization_alias='id')
+    id: Optional[str] = Field(alias="_id",
+                              default=None,
+                              serialization_alias='id')
 
     model_config = ConfigDict(
-        arbitrary_types_allowed=True,
         json_encoders={
             datetime: lambda v: convert_to_tz_aware(v),
-            ObjectId: str,
         },
         populate_by_name=True,
     )

--- a/backend/v1/user_events/user_events_api.py
+++ b/backend/v1/user_events/user_events_api.py
@@ -4,7 +4,6 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from v1.db.models.user import User
 from v1.request_filter import validate_request, require_member
-from v1.db.mongo import user_collection
 import v1.user_events.user_events_db as db
 from v1.user_events.user_events_model import UserEvent, ExtendedUserEvent
 

--- a/backend/v1/user_events/user_events_db.py
+++ b/backend/v1/user_events/user_events_db.py
@@ -1,6 +1,8 @@
-from datetime import datetime, timedelta
+import logging
+from datetime import datetime, timedelta, timezone
 from typing import List
 from sqlalchemy import or_, and_
+from sqlalchemy.exc import IntegrityError
 from v1.user_events.user_events_model import ExtendedUserEvent, UserEvent
 from v1.db.database import get_session
 from v1.db.tables import (
@@ -8,6 +10,8 @@ from v1.db.tables import (
     EventAttendeeTable, EventReportTable, UserTable,
 )
 from v1.utilities import get_current_time
+
+log = logging.getLogger(__name__)
 
 
 def create_user_event(user_event) -> int:
@@ -119,20 +123,26 @@ def update_user_event(event_id: str, user_event: UserEvent) -> bool:
             row.location_latitude = None
             row.location_longitude = None
 
-        # Replace child rows
+        # Replace child rows. Flush deletes before inserts to avoid unique-
+        # constraint violations when the same userId appears in both the old
+        # and new child sets (e.g. a host removed and re-added in one update).
         row.hosts.clear()
+        session.flush()
         for h in data.get("hosts") or []:
             row.hosts.append(EventHostTable(event_id=row.id, userId=h["userId"]))
 
         row.suggested_hosts.clear()
+        session.flush()
         for h in data.get("suggested_hosts") or []:
             row.suggested_hosts.append(EventSuggestedHostTable(event_id=row.id, userId=h["userId"]))
 
         row.attendees.clear()
+        session.flush()
         for a in data.get("attendees") or []:
             row.attendees.append(EventAttendeeTable(event_id=row.id, userId=a["userId"]))
 
         row.reports.clear()
+        session.flush()
         for r in data.get("reports") or []:
             row.reports.append(EventReportTable(event_id=row.id, userId=r["userId"], text=r["text"]))
 
@@ -153,7 +163,9 @@ def delete_user_event(event_id: str) -> bool:
 
 def get_unsafe_future_user_events() -> list[UserEvent]:
     """Retrieves all future user events."""
-    current_time = get_current_time().replace(tzinfo=None)
+    current_time = get_current_time()
+    if current_time.tzinfo is None:
+        current_time = current_time.replace(tzinfo=timezone.utc)
     with get_session() as session:
         rows = session.query(UserEventTable).filter(
             or_(
@@ -234,7 +246,9 @@ def add_attendee_to_user_event(event_id: str, user_id: int) -> bool:
 
     Uses SELECT FOR UPDATE to serialize concurrent requests so that capacity
     and duplicate checks are evaluated against a consistent locked snapshot.
-    The UniqueConstraint on event_attendees acts as a DB-level safety net.
+    The UniqueConstraint on event_attendees acts as a DB-level safety net:
+    a race that bypasses the Python-level check results in IntegrityError
+    which is caught here and treated as "already attending" (returns True).
     """
     try:
         with get_session() as session:
@@ -248,8 +262,11 @@ def add_attendee_to_user_event(event_id: str, user_id: int) -> bool:
             session.add(EventAttendeeTable(event_id=row.id, userId=user_id))
             session.commit()
             return True
-    except Exception:
-        return False
+    except IntegrityError:
+        # Unique constraint fired — the row was inserted by a concurrent request.
+        # The attendee is present, so the operation logically succeeded.
+        log.debug("Duplicate attendee insert blocked by constraint: event=%s user=%s", event_id, user_id)
+        return True
 
 
 def remove_attendee_from_user_event(event_id: str, user_id: int) -> bool:
@@ -411,15 +428,3 @@ def remove_secrets_from_user_events(events: list[UserEvent]) -> list[UserEvent]:
     return [make_user_event_safe(event) for event in events]
 
 
-def restore_secret_fields_on_user_event(event: UserEvent, event_id: str = None) -> UserEvent | None:
-    """Restore secret fields to their original values."""
-    lookup_id = event_id or event.id
-    if not lookup_id:
-        return None
-
-    original_event = get_unsafe_user_event(lookup_id)
-    if not original_event:
-        return None
-
-    event.reports = original_event.reports
-    return event

--- a/backend/v1/user_events/user_events_db.py
+++ b/backend/v1/user_events/user_events_db.py
@@ -1,388 +1,359 @@
 from datetime import datetime, timedelta
 from typing import List
-from bson import ObjectId
+from sqlalchemy import or_, and_
 from v1.user_events.user_events_model import ExtendedUserEvent, UserEvent
-from v1.db.mongo import user_event_collection, user_collection
+from v1.db.database import SessionLocal
+from v1.db.tables import (
+    UserEventTable, EventHostTable, EventSuggestedHostTable,
+    EventAttendeeTable, EventReportTable, UserTable,
+)
 from v1.utilities import get_current_time
 
 
-def create_user_event(user_event: dict) -> ObjectId:
+def create_user_event(user_event) -> int:
     """
     Create a new user event.
 
-    :param user_event: User event data.
-    :return: The created user event ID as ObjectId.
+    :param user_event: User event Pydantic model.
+    :return: The created user event ID.
     """
-    result = user_event_collection.insert_one(user_event.model_dump())
-    return result.inserted_id
+    data = user_event.model_dump()
+    with SessionLocal() as session:
+        row = UserEventTable(
+            userId=data["userId"],
+            name=data["name"],
+            start=data["start"],
+            end=data.get("end"),
+            description=data.get("description"),
+            maxAttendees=data.get("maxAttendees"),
+        )
+        # Location
+        loc = data.get("location")
+        if loc:
+            row.location_description = loc.get("description")
+            row.location_address = loc.get("address")
+            row.location_marker = loc.get("marker")
+            row.location_latitude = loc.get("latitude")
+            row.location_longitude = loc.get("longitude")
+
+        session.add(row)
+        session.flush()  # get the id
+
+        # Hosts
+        for h in data.get("hosts") or []:
+            session.add(EventHostTable(event_id=row.id, userId=h["userId"]))
+        for h in data.get("suggested_hosts") or []:
+            session.add(EventSuggestedHostTable(event_id=row.id, userId=h["userId"]))
+        for a in data.get("attendees") or []:
+            session.add(EventAttendeeTable(event_id=row.id, userId=a["userId"]))
+        for r in data.get("reports") or []:
+            session.add(EventReportTable(event_id=row.id, userId=r["userId"], text=r["text"]))
+
+        session.commit()
+        return row.id
+
+
+def _load_event(session, event_id: int) -> UserEventTable | None:
+    """Load a user event with all relationships."""
+    return session.query(UserEventTable).filter_by(id=int(event_id)).first()
 
 
 def get_unsafe_user_event(event_id: str) -> UserEvent | None:
     """
-    Retrieves a user event document from the MongoDB database.
+    Retrieves a user event from the database.
     This function should only be used for internal operations, as it returns secret fields.
-
-    :param event_id: The event ID.
-    :return: The user event document or None.
     """
     try:
-        event = user_event_collection.find_one({"_id": ObjectId(event_id)})
-        return UserEvent(**event) if event else None
+        with SessionLocal() as session:
+            row = _load_event(session, event_id)
+            return UserEvent(**row.to_dict()) if row else None
     except Exception:
         return None
 
 
 def get_safe_user_event(event_id: str) -> ExtendedUserEvent | None:
     """
-    Retrieves a user event document from the MongoDB database, without secret fields.
-
-    :param event_id: The event ID.
-    :return: The user event document or None.
+    Retrieves a user event from the database, without secret fields.
     """
-
     event = get_unsafe_user_event(event_id)
     if not event:
         return None
-
     return extend_user_event(make_user_event_safe(event))
 
 
 def update_user_event(event_id: str, user_event: UserEvent) -> bool:
     """
-    Updates a user event document in the MongoDB database.
-
-    :param event_id: The event ID.
-    :param user_event: The updated user event data.
-    :return: The number of modified documents.
+    Updates a user event in the database.
     """
-
-    # The incoming user event won't contain any of the secret fields,
-    # so we need to copy them from the existing event before updating.
+    # Restore secret fields from DB before updating
     event = restore_secret_fields_on_user_event(user_event, event_id)
     if not event:
-        return 0
+        return False
 
-    result = user_event_collection.update_one({"_id": ObjectId(event_id)},
-                                              {"$set": event.model_dump()})
-    return result.acknowledged and result.matched_count > 0
+    data = event.model_dump()
+    with SessionLocal() as session:
+        row = _load_event(session, event_id)
+        if not row:
+            return False
+
+        row.userId = data["userId"]
+        row.name = data["name"]
+        row.start = data["start"]
+        row.end = data.get("end")
+        row.description = data.get("description")
+        row.maxAttendees = data.get("maxAttendees")
+
+        loc = data.get("location")
+        if loc:
+            row.location_description = loc.get("description")
+            row.location_address = loc.get("address")
+            row.location_marker = loc.get("marker")
+            row.location_latitude = loc.get("latitude")
+            row.location_longitude = loc.get("longitude")
+        else:
+            row.location_description = None
+            row.location_address = None
+            row.location_marker = None
+            row.location_latitude = None
+            row.location_longitude = None
+
+        # Replace child rows
+        row.hosts.clear()
+        for h in data.get("hosts") or []:
+            row.hosts.append(EventHostTable(event_id=row.id, userId=h["userId"]))
+
+        row.suggested_hosts.clear()
+        for h in data.get("suggested_hosts") or []:
+            row.suggested_hosts.append(EventSuggestedHostTable(event_id=row.id, userId=h["userId"]))
+
+        row.attendees.clear()
+        for a in data.get("attendees") or []:
+            row.attendees.append(EventAttendeeTable(event_id=row.id, userId=a["userId"]))
+
+        row.reports.clear()
+        for r in data.get("reports") or []:
+            row.reports.append(EventReportTable(event_id=row.id, userId=r["userId"], text=r["text"]))
+
+        session.commit()
+        return True
 
 
 def delete_user_event(event_id: str) -> bool:
-    """
-    Deletes a user event document from the MongoDB database.
-
-    :param event_id: The event ID.
-    :return: The number of deleted documents.
-    """
-    result = user_event_collection.delete_one({"_id": ObjectId(event_id)})
-    return result.acknowledged
+    """Deletes a user event from the database."""
+    with SessionLocal() as session:
+        row = _load_event(session, event_id)
+        if not row:
+            return False
+        session.delete(row)
+        session.commit()
+        return True
 
 
 def get_unsafe_future_user_events() -> list[UserEvent]:
-    """
-    Retrieves all future user events from the MongoDB database.
-    This function should only be used for internal operations, as it returns secret fields.
-
-    :return: The user event documents.
-    """
+    """Retrieves all future user events."""
     current_time = get_current_time().replace(tzinfo=None)
-    query = {
-        "$or": [{
-            "end": {
-                "$gte": current_time
-            }
-        }, {
-            "start": {
-                "$gte": current_time - timedelta(hours=1)
-            },
-            "end": None
-        }]
-    }
-
-    return [
-        UserEvent(**event) for event in list(user_event_collection.find(query))
-    ]
+    with SessionLocal() as session:
+        rows = session.query(UserEventTable).filter(
+            or_(
+                UserEventTable.end >= current_time,
+                and_(
+                    UserEventTable.start >= current_time - timedelta(hours=1),
+                    UserEventTable.end.is_(None),
+                ),
+            )
+        ).all()
+        return [UserEvent(**row.to_dict()) for row in rows]
 
 
 def get_safe_future_user_events() -> list[ExtendedUserEvent]:
-    """
-    Retrieves all future user events from the MongoDB database.
-    :return: The user event documents.
-    """
-
+    """Retrieves all future user events, without secret fields."""
     return extend_user_events(
         remove_secrets_from_user_events(get_unsafe_future_user_events()))
 
 
 def get_safe_user_events_since(since: datetime) -> list[ExtendedUserEvent]:
-    """
-    Retrieves all user events with start >= `since`.
-    :param since: Lower bound datetime for event start.
-    :return: The user event documents.
-    """
-    query = {"start": {"$gte": since}}
-    events = [UserEvent(**e) for e in user_event_collection.find(query)]
+    """Retrieves all user events with start >= `since`."""
+    with SessionLocal() as session:
+        rows = session.query(UserEventTable).filter(
+            UserEventTable.start >= since
+        ).all()
+        events = [UserEvent(**row.to_dict()) for row in rows]
     return extend_user_events(remove_secrets_from_user_events(events))
 
 
 def get_unsafe_user_events_user_owns(userId: int) -> list[UserEvent]:
-    """
-    Retrieves all user events that a user is hosting.
-    This function should only be used for internal operations, as it returns secret fields.
-
-    :param userId: The ID of the user.
-    :return: The user event documents.
-    """
-    query = {"userId": userId}
-    return [UserEvent(**event) for event in user_event_collection.find(query)]
+    """Retrieves all user events that a user owns."""
+    with SessionLocal() as session:
+        rows = session.query(UserEventTable).filter_by(userId=userId).all()
+        return [UserEvent(**row.to_dict()) for row in rows]
 
 
 def get_safe_user_events_user_owns(userId: int) -> list[ExtendedUserEvent]:
-    """
-    Retrieves all user events that a user is hosting.
-
-    :param userId: The ID of the user.
-    :return: The user event documents.
-    """
-
+    """Retrieves all user events that a user owns."""
     return extend_user_events(
         remove_secrets_from_user_events(
             get_unsafe_user_events_user_owns(userId)))
 
 
 def get_unsafe_user_events_user_is_hosting(userId: int) -> list[UserEvent]:
-    """
-    Retrieves all user events that a user is hosting.
-    This function should only be used for internal operations, as it returns secret fields.
-
-    :param userId: The ID of the user.
-    :return: The user event documents.
-    """
-    query = {"hosts": {"$elemMatch": {"userId": userId}}}
-    return [UserEvent(**event) for event in user_event_collection.find(query)]
+    """Retrieves all user events that a user is hosting."""
+    with SessionLocal() as session:
+        rows = session.query(UserEventTable).join(EventHostTable).filter(
+            EventHostTable.userId == userId
+        ).all()
+        return [UserEvent(**row.to_dict()) for row in rows]
 
 
-def get_safe_user_events_user_is_hosting(
-        userId: int) -> list[ExtendedUserEvent]:
-    """
-    Retrieves all user events that a user is hosting.
-
-    :param userId: The ID of the user.
-    :return: The user event documents.
-    """
-
+def get_safe_user_events_user_is_hosting(userId: int) -> list[ExtendedUserEvent]:
+    """Retrieves all user events that a user is hosting."""
     return extend_user_events(
         remove_secrets_from_user_events(
             get_unsafe_user_events_user_is_hosting(userId)))
 
 
 def get_unsafe_user_events_user_is_attending(userId: int) -> list[UserEvent]:
-    """
-    Retrieves all user events that a user is attending.
-    This function should only be used for internal operations, as it returns secret fields.
-
-    :param userId: The ID of the user.
-    :return: The user event documents.
-    """
-    query = {"attendees": {"$elemMatch": {"userId": userId}}}
-    return [UserEvent(**event) for event in user_event_collection.find(query)]
+    """Retrieves all user events that a user is attending."""
+    with SessionLocal() as session:
+        rows = session.query(UserEventTable).join(EventAttendeeTable).filter(
+            EventAttendeeTable.userId == userId
+        ).all()
+        return [UserEvent(**row.to_dict()) for row in rows]
 
 
-def get_safe_user_events_user_is_attending(
-        userId: int) -> list[ExtendedUserEvent]:
-    """
-    Retrieves all user events that a user is attending.
-
-    :param userId: The ID of the user.
-    :return: The user event documents.
-    """
+def get_safe_user_events_user_is_attending(userId: int) -> list[ExtendedUserEvent]:
+    """Retrieves all user events that a user is attending."""
     return extend_user_events(
         remove_secrets_from_user_events(
             get_unsafe_user_events_user_is_attending(userId)))
 
 
 def add_attendee_to_user_event(event_id: str, user_id: int) -> bool:
-    """
-    Adds a user to the attendees list of an event, ensuring no duplicates.
-
-    :param event_id: The ID of the event.
-    :param user_id: The ID of the user to add.
-    :return: The number of modified documents.
-    """
+    """Adds a user to the attendees list of an event, ensuring no duplicates."""
     try:
-        event = get_unsafe_user_event(event_id)
-        if event and event.maxAttendees is not None and len(event.attendees) >= event.maxAttendees:
-            return False
-        result = user_event_collection.update_one(
-            {"_id": ObjectId(event_id)},
-            {"$addToSet": {
-                "attendees": {
-                    "userId": user_id
-                }
-            }})
-        return result.acknowledged and result.matched_count > 0
+        with SessionLocal() as session:
+            row = _load_event(session, event_id)
+            if not row:
+                return False
+            if row.maxAttendees is not None and len(row.attendees) >= row.maxAttendees:
+                return False
+            # Check for duplicate
+            if any(a.userId == user_id for a in row.attendees):
+                return True
+            session.add(EventAttendeeTable(event_id=row.id, userId=user_id))
+            session.commit()
+            return True
     except Exception:
         return False
 
 
 def remove_attendee_from_user_event(event_id: str, user_id: int) -> bool:
-    """
-    Removes a user from the attendees list of an event.
-
-    :param event_id: The ID of the event.
-    :param user_id: The ID of the user to remove.
-    :return: The number of modified documents.
-    """
-    result = user_event_collection.update_one(
-        {"_id": ObjectId(event_id)},
-        {"$pull": {
-            "attendees": {
-                "userId": user_id
-            }
-        }})
-    return result.acknowledged and result.matched_count > 0
+    """Removes a user from the attendees list of an event."""
+    with SessionLocal() as session:
+        row = _load_event(session, event_id)
+        if not row:
+            return False
+        attendee = next((a for a in row.attendees if a.userId == user_id), None)
+        if attendee:
+            session.delete(attendee)
+            session.commit()
+            return True
+        return False
 
 
 ### Hosts and host invites ###
 
 
-def get_unsafe_user_events_user_is_invited_to_host(
-        userId: int) -> list[UserEvent]:
-    """
-    Retrieves all user events that a user is suggested to co-host.
-    This function should only be used for internal operations, as it returns secret fields.
-
-    :param userId: The ID of the user.
-    :return: The user event documents.
-    """
-    query = {"suggested_hosts": {"$elemMatch": {"userId": userId}}}
-    return [UserEvent(**event) for event in user_event_collection.find(query)]
+def get_unsafe_user_events_user_is_invited_to_host(userId: int) -> list[UserEvent]:
+    """Retrieves all user events that a user is suggested to co-host."""
+    with SessionLocal() as session:
+        rows = session.query(UserEventTable).join(EventSuggestedHostTable).filter(
+            EventSuggestedHostTable.userId == userId
+        ).all()
+        return [UserEvent(**row.to_dict()) for row in rows]
 
 
-def get_safe_user_events_user_is_invited_to_host(
-        userId: int) -> list[ExtendedUserEvent]:
-    """
-    Retrieves all user events that a user is suggested to co-host.
-
-    :param userId: The ID of the user.
-    :return: The user event documents.
-    """
+def get_safe_user_events_user_is_invited_to_host(userId: int) -> list[ExtendedUserEvent]:
+    """Retrieves all user events that a user is suggested to co-host."""
     return extend_user_events(
         remove_secrets_from_user_events(
             get_unsafe_user_events_user_is_invited_to_host(userId)))
 
 
 def add_user_as_host_to_user_event(event_id: str, user_id: int) -> bool:
-    """
-    Adds a user to the hosts list of an event, ensuring no duplicates.
-
-    :param event_id: The ID of the event.
-    :param user_id: The ID of the user to add.
-    :return: The number of modified documents.
-    """
-    result = user_event_collection.update_one({"_id": ObjectId(event_id)}, {
-        "$addToSet": {
-            "hosts": {
-                "userId": user_id
-            }
-        },
-        "$pull": {
-            "suggested_hosts": {
-                "userId": user_id
-            }
-        }
-    })
-    return result.acknowledged and result.matched_count > 0
+    """Adds a user to the hosts list and removes from suggested_hosts."""
+    with SessionLocal() as session:
+        row = _load_event(session, event_id)
+        if not row:
+            return False
+        # Add to hosts if not already there
+        if not any(h.userId == user_id for h in row.hosts):
+            session.add(EventHostTable(event_id=row.id, userId=user_id))
+        # Remove from suggested_hosts
+        suggested = next((s for s in row.suggested_hosts if s.userId == user_id), None)
+        if suggested:
+            session.delete(suggested)
+        session.commit()
+        return True
 
 
 def remove_user_from_hosts_of_user_event(event_id: str, user_id: int) -> bool:
-    """
-    Removes a user from the hosts list of an event.
-
-    :param event_id: The ID of the event.
-    :param user_id: The ID of the user to remove.
-    :return: The number of modified documents.
-    """
-    result = user_event_collection.update_one(
-        {"_id": ObjectId(event_id)}, {"$pull": {
-            "hosts": {
-                "userId": user_id
-            }
-        }})
-    return result.acknowledged and result.matched_count > 0
+    """Removes a user from the hosts list of an event."""
+    with SessionLocal() as session:
+        row = _load_event(session, event_id)
+        if not row:
+            return False
+        host = next((h for h in row.hosts if h.userId == user_id), None)
+        if host:
+            session.delete(host)
+            session.commit()
+            return True
+        return False
 
 
-def remove_user_host_invitation_from_user_event(event_id: str,
-                                                user_id: int) -> bool:
-    """
-    Removes a user from the suggested hosts list of an event.
-
-    :param event_id: The ID of the event.
-    :param user_id: The ID of the user to remove.
-    :return: The number of modified documents.
-    """
-    result = user_event_collection.update_one(
-        {"_id": ObjectId(event_id)},
-        {"$pull": {
-            "suggested_hosts": {
-                "userId": user_id
-            }
-        }})
-    return result.acknowledged and result.matched_count > 0
+def remove_user_host_invitation_from_user_event(event_id: str, user_id: int) -> bool:
+    """Removes a user from the suggested hosts list of an event."""
+    with SessionLocal() as session:
+        row = _load_event(session, event_id)
+        if not row:
+            return False
+        suggested = next((s for s in row.suggested_hosts if s.userId == user_id), None)
+        if suggested:
+            session.delete(suggested)
+            session.commit()
+            return True
+        return False
 
 
 ### Reports ###
 
 
-def add_or_update_report_on_user_event(event_id: str, user_id: int,
-                                       report: str) -> bool:
-    """
-    Adds a report to an event, or updates an existing report.
-
-    :param event_id: The ID of the event.
-    :param user_id: The ID of the user making the report.
-    :param report: The report text.
-    :return: The number of modified documents.
-    """
-
-    result = user_event_collection.update_one(
-        {"_id": ObjectId(event_id)},
-        {"$set": {
-            "reports.$[elem].text": report
-        }},
-        array_filters=[{
-            "elem.userId": user_id
-        }])
-
-    if result.modified_count == 0:
-        result = user_event_collection.update_one(
-            {"_id": ObjectId(event_id)},
-            {"$addToSet": {
-                "reports": {
-                    "userId": user_id,
-                    "text": report
-                }
-            }})
-
-    return result.acknowledged and result.matched_count > 0
+def add_or_update_report_on_user_event(event_id: str, user_id: int, report: str) -> bool:
+    """Adds a report to an event, or updates an existing report."""
+    with SessionLocal() as session:
+        row = _load_event(session, event_id)
+        if not row:
+            return False
+        existing = next((r for r in row.reports if r.userId == user_id), None)
+        if existing:
+            existing.text = report
+        else:
+            session.add(EventReportTable(event_id=row.id, userId=user_id, text=report))
+        session.commit()
+        return True
 
 
 def remove_report_from_user_event(event_id: str, user_id: int) -> bool:
-    """
-    Removes a report from an event.
-
-    :param event_id: The ID of the event.
-    :param user_id: The ID of the user making the report.
-    :return: The number of modified documents.
-    """
-    result = user_event_collection.update_one(
-        {"_id": ObjectId(event_id)},
-        {"$pull": {
-            "reports": {
-                "userId": user_id
-            }
-        }})
-    return result.acknowledged and result.matched_count > 0
+    """Removes a report from an event."""
+    with SessionLocal() as session:
+        row = _load_event(session, event_id)
+        if not row:
+            return False
+        existing = next((r for r in row.reports if r.userId == user_id), None)
+        if existing:
+            session.delete(existing)
+            session.commit()
+            return True
+        return False
 
 
 ### Utilities ###
@@ -393,7 +364,6 @@ def extend_user_event(event: UserEvent) -> ExtendedUserEvent:
 
 
 def extend_user_events(events: List[UserEvent]) -> List[ExtendedUserEvent]:
-
     # Fetch user IDs
     user_ids = set()
     for event in events:
@@ -405,79 +375,45 @@ def extend_user_events(events: List[UserEvent]) -> List[ExtendedUserEvent]:
 
     # Fetch user names
     user_names = {}
-    users = user_collection.find({"userId": {"$in": user_ids}})
+    with SessionLocal() as session:
+        users = session.query(UserTable).filter(UserTable.userId.in_(user_ids)).all()
+        for user in users:
+            user_names[user.userId] = f"{user.firstName} {user.lastName}"
 
-    for user in users:
-        user_id = user["userId"]
-        user_names[user_id] = f"{user['firstName']} {user['lastName']}"
-
-    def extend_user_event(event: dict,
-                          user_names: dict[int, str]) -> ExtendedUserEvent:
-        """
-        Extends a user event document with user names.
-
-        :param event: The user event document.
-        :param user_names: A dictionary of user IDs and names.
-        :return: The extended user event document.
-        """
-        event["ownerName"] = user_names[event["userId"]]
-        event["hostNames"] = [
-            user_names[host["userId"]] for host in event["hosts"]
+    def _extend(event_dict: dict, user_names: dict[int, str]) -> ExtendedUserEvent:
+        event_dict["ownerName"] = user_names.get(event_dict["userId"], "Unknown")
+        event_dict["hostNames"] = [
+            user_names.get(host["userId"], "Unknown") for host in event_dict["hosts"]
         ]
-        event["attendeeNames"] = [
-            user_names[attendee["userId"]] for attendee in event["attendees"]
+        event_dict["attendeeNames"] = [
+            user_names.get(attendee["userId"], "Unknown") for attendee in event_dict["attendees"]
         ]
-
-        return ExtendedUserEvent(**event)
+        return ExtendedUserEvent(**event_dict)
 
     event_dicts = [event.model_dump() for event in events]
-    return [
-        extend_user_event(event_dict, user_names) for event_dict in event_dicts
-    ]
+    return [_extend(event_dict, user_names) for event_dict in event_dicts]
 
 
 def make_user_event_safe(event: UserEvent) -> UserEvent:
-    """
-    Set secret fields to their model default values in a user event document, to make it safe to return to the client.
-
-    :param event: The user event document.
-    :return: The user event document with secrets removed.
-    """
+    """Set secret fields to their model default values."""
     event.reports = []
-
     return event
 
 
-def remove_secrets_from_user_events(
-        events: list[UserEvent]) -> list[UserEvent]:
-    """
-    Set secret fields to their model default values in a list of user event documents.
-
-    :param events: The user event documents.
-    :return: The user event documents with secrets removed.
-    """
+def remove_secrets_from_user_events(events: list[UserEvent]) -> list[UserEvent]:
+    """Set secret fields to their model default values in a list of user events."""
     return [make_user_event_safe(event) for event in events]
 
 
 def restore_secret_fields_on_user_event(event: UserEvent, event_id: str = None) -> UserEvent | None:
-    """
-    Restore secret fields to their original values in a user event document.
-
-    :param event: The user event document.
-    :param event_id: The event ID to fetch original data from (optional, falls back to event.id)
-    :return: The user event document with secrets restored.
-    """
-
-    # Use provided event_id or fall back to event.id for backward compatibility
+    """Restore secret fields to their original values."""
     lookup_id = event_id or event.id
     if not lookup_id:
         return None
-        
-    original_event = get_unsafe_user_event(lookup_id)
 
+    original_event = get_unsafe_user_event(lookup_id)
     if not original_event:
         return None
 
     event.reports = original_event.reports
-
     return event

--- a/backend/v1/user_events/user_events_db.py
+++ b/backend/v1/user_events/user_events_db.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 from typing import List
 from sqlalchemy import or_, and_
 from v1.user_events.user_events_model import ExtendedUserEvent, UserEvent
-from v1.db.database import SessionLocal
+from v1.db.database import get_session
 from v1.db.tables import (
     UserEventTable, EventHostTable, EventSuggestedHostTable,
     EventAttendeeTable, EventReportTable, UserTable,
@@ -18,7 +18,7 @@ def create_user_event(user_event) -> int:
     :return: The created user event ID.
     """
     data = user_event.model_dump()
-    with SessionLocal() as session:
+    with get_session() as session:
         row = UserEventTable(
             userId=data["userId"],
             name=data["name"],
@@ -64,7 +64,7 @@ def get_unsafe_user_event(event_id: str) -> UserEvent | None:
     This function should only be used for internal operations, as it returns secret fields.
     """
     try:
-        with SessionLocal() as session:
+        with get_session() as session:
             row = _load_event(session, event_id)
             return UserEvent(**row.to_dict()) if row else None
     except Exception:
@@ -91,7 +91,7 @@ def update_user_event(event_id: str, user_event: UserEvent) -> bool:
         return False
 
     data = event.model_dump()
-    with SessionLocal() as session:
+    with get_session() as session:
         row = _load_event(session, event_id)
         if not row:
             return False
@@ -140,7 +140,7 @@ def update_user_event(event_id: str, user_event: UserEvent) -> bool:
 
 def delete_user_event(event_id: str) -> bool:
     """Deletes a user event from the database."""
-    with SessionLocal() as session:
+    with get_session() as session:
         row = _load_event(session, event_id)
         if not row:
             return False
@@ -152,7 +152,7 @@ def delete_user_event(event_id: str) -> bool:
 def get_unsafe_future_user_events() -> list[UserEvent]:
     """Retrieves all future user events."""
     current_time = get_current_time().replace(tzinfo=None)
-    with SessionLocal() as session:
+    with get_session() as session:
         rows = session.query(UserEventTable).filter(
             or_(
                 UserEventTable.end >= current_time,
@@ -173,7 +173,7 @@ def get_safe_future_user_events() -> list[ExtendedUserEvent]:
 
 def get_safe_user_events_since(since: datetime) -> list[ExtendedUserEvent]:
     """Retrieves all user events with start >= `since`."""
-    with SessionLocal() as session:
+    with get_session() as session:
         rows = session.query(UserEventTable).filter(
             UserEventTable.start >= since
         ).all()
@@ -183,7 +183,7 @@ def get_safe_user_events_since(since: datetime) -> list[ExtendedUserEvent]:
 
 def get_unsafe_user_events_user_owns(userId: int) -> list[UserEvent]:
     """Retrieves all user events that a user owns."""
-    with SessionLocal() as session:
+    with get_session() as session:
         rows = session.query(UserEventTable).filter_by(userId=userId).all()
         return [UserEvent(**row.to_dict()) for row in rows]
 
@@ -197,7 +197,7 @@ def get_safe_user_events_user_owns(userId: int) -> list[ExtendedUserEvent]:
 
 def get_unsafe_user_events_user_is_hosting(userId: int) -> list[UserEvent]:
     """Retrieves all user events that a user is hosting."""
-    with SessionLocal() as session:
+    with get_session() as session:
         rows = session.query(UserEventTable).join(EventHostTable).filter(
             EventHostTable.userId == userId
         ).all()
@@ -213,7 +213,7 @@ def get_safe_user_events_user_is_hosting(userId: int) -> list[ExtendedUserEvent]
 
 def get_unsafe_user_events_user_is_attending(userId: int) -> list[UserEvent]:
     """Retrieves all user events that a user is attending."""
-    with SessionLocal() as session:
+    with get_session() as session:
         rows = session.query(UserEventTable).join(EventAttendeeTable).filter(
             EventAttendeeTable.userId == userId
         ).all()
@@ -230,7 +230,7 @@ def get_safe_user_events_user_is_attending(userId: int) -> list[ExtendedUserEven
 def add_attendee_to_user_event(event_id: str, user_id: int) -> bool:
     """Adds a user to the attendees list of an event, ensuring no duplicates."""
     try:
-        with SessionLocal() as session:
+        with get_session() as session:
             row = _load_event(session, event_id)
             if not row:
                 return False
@@ -248,7 +248,7 @@ def add_attendee_to_user_event(event_id: str, user_id: int) -> bool:
 
 def remove_attendee_from_user_event(event_id: str, user_id: int) -> bool:
     """Removes a user from the attendees list of an event."""
-    with SessionLocal() as session:
+    with get_session() as session:
         row = _load_event(session, event_id)
         if not row:
             return False
@@ -265,7 +265,7 @@ def remove_attendee_from_user_event(event_id: str, user_id: int) -> bool:
 
 def get_unsafe_user_events_user_is_invited_to_host(userId: int) -> list[UserEvent]:
     """Retrieves all user events that a user is suggested to co-host."""
-    with SessionLocal() as session:
+    with get_session() as session:
         rows = session.query(UserEventTable).join(EventSuggestedHostTable).filter(
             EventSuggestedHostTable.userId == userId
         ).all()
@@ -281,7 +281,7 @@ def get_safe_user_events_user_is_invited_to_host(userId: int) -> list[ExtendedUs
 
 def add_user_as_host_to_user_event(event_id: str, user_id: int) -> bool:
     """Adds a user to the hosts list and removes from suggested_hosts."""
-    with SessionLocal() as session:
+    with get_session() as session:
         row = _load_event(session, event_id)
         if not row:
             return False
@@ -298,7 +298,7 @@ def add_user_as_host_to_user_event(event_id: str, user_id: int) -> bool:
 
 def remove_user_from_hosts_of_user_event(event_id: str, user_id: int) -> bool:
     """Removes a user from the hosts list of an event."""
-    with SessionLocal() as session:
+    with get_session() as session:
         row = _load_event(session, event_id)
         if not row:
             return False
@@ -312,7 +312,7 @@ def remove_user_from_hosts_of_user_event(event_id: str, user_id: int) -> bool:
 
 def remove_user_host_invitation_from_user_event(event_id: str, user_id: int) -> bool:
     """Removes a user from the suggested hosts list of an event."""
-    with SessionLocal() as session:
+    with get_session() as session:
         row = _load_event(session, event_id)
         if not row:
             return False
@@ -329,7 +329,7 @@ def remove_user_host_invitation_from_user_event(event_id: str, user_id: int) -> 
 
 def add_or_update_report_on_user_event(event_id: str, user_id: int, report: str) -> bool:
     """Adds a report to an event, or updates an existing report."""
-    with SessionLocal() as session:
+    with get_session() as session:
         row = _load_event(session, event_id)
         if not row:
             return False
@@ -344,7 +344,7 @@ def add_or_update_report_on_user_event(event_id: str, user_id: int, report: str)
 
 def remove_report_from_user_event(event_id: str, user_id: int) -> bool:
     """Removes a report from an event."""
-    with SessionLocal() as session:
+    with get_session() as session:
         row = _load_event(session, event_id)
         if not row:
             return False
@@ -375,7 +375,7 @@ def extend_user_events(events: List[UserEvent]) -> List[ExtendedUserEvent]:
 
     # Fetch user names
     user_names = {}
-    with SessionLocal() as session:
+    with get_session() as session:
         users = session.query(UserTable).filter(UserTable.userId.in_(user_ids)).all()
         for user in users:
             user_names[user.userId] = f"{user.firstName} {user.lastName}"

--- a/backend/v1/user_events/user_events_db.py
+++ b/backend/v1/user_events/user_events_db.py
@@ -84,17 +84,19 @@ def get_safe_user_event(event_id: str) -> ExtendedUserEvent | None:
 def update_user_event(event_id: str, user_event: UserEvent) -> bool:
     """
     Updates a user event in the database.
-    """
-    # Restore secret fields from DB before updating
-    event = restore_secret_fields_on_user_event(user_event, event_id)
-    if not event:
-        return False
 
-    data = event.model_dump()
+    Uses a single locked session to atomically restore secret fields and apply
+    the update, eliminating the two-session TOCTOU race in the old implementation.
+    """
+    data = user_event.model_dump()
     with get_session() as session:
-        row = _load_event(session, event_id)
+        row = session.query(UserEventTable).with_for_update().filter_by(id=int(event_id)).first()
         if not row:
             return False
+
+        # Restore secret fields (reports) from the locked row so callers that
+        # received a sanitized event cannot accidentally clear them.
+        data["reports"] = [{"userId": r.userId, "text": r.text} for r in row.reports]
 
         row.userId = data["userId"]
         row.name = data["name"]
@@ -228,15 +230,19 @@ def get_safe_user_events_user_is_attending(userId: int) -> list[ExtendedUserEven
 
 
 def add_attendee_to_user_event(event_id: str, user_id: int) -> bool:
-    """Adds a user to the attendees list of an event, ensuring no duplicates."""
+    """Adds a user to the attendees list of an event, ensuring no duplicates.
+
+    Uses SELECT FOR UPDATE to serialize concurrent requests so that capacity
+    and duplicate checks are evaluated against a consistent locked snapshot.
+    The UniqueConstraint on event_attendees acts as a DB-level safety net.
+    """
     try:
         with get_session() as session:
-            row = _load_event(session, event_id)
+            row = session.query(UserEventTable).with_for_update().filter_by(id=int(event_id)).first()
             if not row:
                 return False
             if row.maxAttendees is not None and len(row.attendees) >= row.maxAttendees:
                 return False
-            # Check for duplicate
             if any(a.userId == user_id for a in row.attendees):
                 return True
             session.add(EventAttendeeTable(event_id=row.id, userId=user_id))

--- a/backend/v1/utilities.py
+++ b/backend/v1/utilities.py
@@ -15,7 +15,7 @@ def get_current_time_zone():
 def convert_string_to_datetime(datestring: str):
     return datetime.strptime(datestring, '%Y-%m-%d')
 
-# Convert naive datetime to timezone aware datetime. This is necessary because MongoDB stores all datetimes in UTC
+# Convert naive datetime to timezone aware datetime
 def convert_to_tz_aware(naive_dt):
     aware_dt = naive_dt.replace(tzinfo=pytz.utc).astimezone(get_current_time_zone())
     return aware_dt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,9 +10,10 @@ services:
     ports:
       - "${BACKEND_PORT:-5000}:5000"
     depends_on:
-      - mongo
+      - postgres
     restart: unless-stopped
     environment:
+      DATABASE_URL: postgresql://swag:swag@postgres:5432/swag
       GIT_COMMIT_INFO: 'Commit messages are not available locally'
       GIT_COMMIT_HASH: ''
       LOGINM_SEED: ${LOGINM_SEED}
@@ -34,23 +35,16 @@ services:
       GITHUB_APP_PRIVATE_KEY: ${GITHUB_APP_PRIVATE_KEY:-}
       PUBLIC_BASE_URL: ${PUBLIC_BASE_URL:-http://100.104.188.36:8043}
 
-  mongo:
-    image: mongo:latest
+  postgres:
+    image: postgres:16
     volumes:
-      - mongodata:/data/db
-
-  mongo-express:
-    image: mongo-express:latest
-    ports:
-      - "8082:8081"
-    depends_on:
-      - mongo
-    restart: unless-stopped
+      - pgdata:/var/lib/postgresql/data
     environment:
-      ME_CONFIG_MONGODB_SERVER: mongo
-      ME_CONFIG_MONGODB_PORT: 27017
-      ME_CONFIG_BASICAUTH_USERNAME: admin
-      ME_CONFIG_BASICAUTH_PASSWORD: admin
+      POSTGRES_USER: swag
+      POSTGRES_PASSWORD: swag
+      POSTGRES_DB: swag
+    ports:
+      - "5432:5432"
 
 volumes:
-  mongodata:
+  pgdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,8 @@ services:
     ports:
       - "${BACKEND_PORT:-5000}:5000"
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
     restart: unless-stopped
     environment:
       DATABASE_URL: postgresql://swag:swag@postgres:5432/swag
@@ -45,6 +46,12 @@ services:
       POSTGRES_DB: swag
     ports:
       - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U swag -d swag"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
 
 volumes:
   pgdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,27 @@ services:
       GITHUB_APP_PRIVATE_KEY: ${GITHUB_APP_PRIVATE_KEY:-}
       PUBLIC_BASE_URL: ${PUBLIC_BASE_URL:-http://100.104.188.36:8043}
 
+  # One-time Mongo → Postgres data migration.
+  # Run with: docker compose --profile migrate up migrate
+  # It exits 0 on success; re-running is safe (idempotent).
+  migrate:
+    image: python:3.11
+    volumes:
+      - ./backend:/app
+    working_dir: /app
+    command: >
+      bash -c "pip install -r v1/requirements.txt pymongo --quiet &&
+               python -m migrations.mongo_to_postgres"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      MONGO_URL: ${MONGO_URL:-mongodb://mongo:27017}
+      DATABASE_URL: postgresql://swag:swag@postgres:5432/swag
+    restart: "no"
+    profiles:
+      - migrate
+
   postgres:
     image: postgres:16
     volumes:


### PR DESCRIPTION
## Overview

Full backend migration from MongoDB (PyMongo) to PostgreSQL (SQLAlchemy ORM). Every data layer rewritten.

**Status: READY FOR REVIEW — all tasks complete, 84 tests pass.**

All work happens on `feature/postgres-migration`.

## What changed

- `v1/db/database.py` — SQLAlchemy engine, session factory, initialize_db() with Alembic migration runner
- `v1/db/tables.py` — all ORM table definitions with proper constraints, indexes, audit columns
- `v1/db/users.py` — rewritten with full profile/privacy columns, tzinfo-safe datetime handling
- `v1/db/external_events.py` — rewritten with per-event transactions
- `v1/db/external_token_storage.py` — rewritten
- `v1/db/external_bookings.py` — new SQLAlchemy implementation
- `v1/user_events/user_events_db.py` — rewritten with SELECT FOR UPDATE, unique constraints, single-session updates
- `v1/jobs/refresh_events.py` — updated
- `v1/server.py` — updated
- `docker-compose.yml` — postgres replaces mongo; healthcheck + startup retry
- `backend/alembic/` — full Alembic migration setup (001_initial_schema.py covers all 15 tables)
- `backend/migrations/mongo_to_postgres.py` — idempotent data migration script
- `backend/tests/` — 84 tests using StaticPool for round-trip validation

## Completed tasks

- ✅ `swagapp-xhdxk` — Fixed ShowLocation import error in users.py
- ✅ `swagapp-trpcp` — Migrated feedback system from PyMongo to SQLAlchemy
- ✅ `swagapp-22z4j` — Added 11+ missing profile and privacy columns to UserTable
- ✅ `swagapp-4040f` — Fixed show_email/show_phone column type (Boolean → PrivacySetting enum)
- ✅ `swagapp-4x90w` — Fixed datetime timezone handling (DateTime(timezone=True) everywhere)
- ✅ `swagapp-7fo6l` — Fixed ExternalRootTable single-row invariant
- ✅ `swagapp-036qm` — Added missing indexes and FK constraints
- ✅ `swagapp-49zpt` — Fixed session management: explicit commit/rollback on all write paths
- ✅ `swagapp-os0it` — Fixed store_external_event_details: per-event transactions
- ✅ `swagapp-ce6tu` — Fixed refresh_external_bookings: distinguish API error from empty list
- ✅ `swagapp-ll0s9` — Fixed restore_secret_fields_on_user_event: eliminated TOCTOU race (single-session with FOR UPDATE)
- ✅ `swagapp-ox5py` — Fixed update_user_from_authresponse: absent type key no longer demotes member
- ✅ `swagapp-l68d1` — Added unique constraints + SELECT FOR UPDATE on event attendees/hosts
- ✅ `swagapp-3jo2f` — Added postgres healthcheck to docker-compose + startup retry
- ✅ `swagapp-zdl9h` — Added Alembic for schema migrations
- ✅ `swagapp-nsk1c` — Added created_at/updated_at audit columns
- ✅ `swagapp-gz5y0` — Fixed test suite: StaticPool so round-trips actually validate
- ✅ `swagapp-6949s` — Wrote Mongo→Postgres data migration script

🤖 Generated with [Claude Code](https://claude.ai/claude-code)