### PR TITLE
feat(events): add interest tag picker to event form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,4 @@ yarn-error.log
 .vscode/user-data/
 shots/
 .claude/settings.local.json
+.grit-attachments/

--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,4 @@ yarn-error.log
 .vscode/extensions/
 .vscode/user-data/
 shots/
+.claude/settings.local.json

--- a/backend/__tests__/unified_events-test.py
+++ b/backend/__tests__/unified_events-test.py
@@ -1,9 +1,9 @@
 import datetime
-from v1.events.events_mappers import map_external_event, map_user_event
+from v1.events.events_mappers import map_external_event, map_user_event, map_event_to_user_event
 from v1.events.events_service import list_unified_events
 from v1.db.models.external_events import ExternalEventDetails, Category
 from v1.user_events.user_events_model import ExtendedUserEvent, UserEvent, Attendee, Host, Location
-from v1.events.events_model import Event, EventAttendee
+from v1.events.events_model import Event, EventAttendee, Tag
 
 class DummyExtendedUserEvent(ExtendedUserEvent):
     pass
@@ -278,4 +278,89 @@ def test_unattend_external_event_syncs_booking(monkeypatch):
     current_user = {"userId": 5, "settings": {}, "isMember": True}
     svc._unattend_external_event("ext400", current_user)
     assert (5, 400) in deleted
+
+
+# ── event-tags round-trip tests ──────────────────────────────────────────────
+
+def _make_event_with_tags(tags: list[Tag]) -> Event:
+    start = datetime.datetime.now() + datetime.timedelta(hours=2)
+    return Event(
+        id="usr123",
+        parentEvent=None,
+        admin=[42],
+        hosts=[],
+        name="Tagged Event",
+        tags=tags,
+        locationDescription="Somewhere",
+        address=None,
+        locationMarker=None,
+        latitude=None,
+        longitude=None,
+        start=start,
+        end=start + datetime.timedelta(hours=1),
+        cancelled=None,
+        imageUrl=None,
+        description="An event with tags",
+        bookingStart=None,
+        bookingEnd=start,
+        showAttendees="all",
+        attendees=[],
+        queue=[],
+        maxAttendees=None,
+        price=0.0,
+        official=False,
+        attending=False,
+        bookable=True,
+        extras={},
+    )
+
+
+def test_map_event_to_user_event_preserves_tags():
+    tags = [
+        Tag(code="logic", text="Logik", colorText="#fff", colorBackground="#333"),
+        Tag(code="chess", text="Schack", colorText="#000", colorBackground="#eee"),
+    ]
+    event = _make_event_with_tags(tags)
+    ue = map_event_to_user_event(event, owner_id=42)
+    assert len(ue.tags) == 2
+    assert ue.tags[0].code == "logic"
+    assert ue.tags[1].code == "chess"
+
+
+def test_map_user_event_returns_stored_tags():
+    tags = [Tag(code="math", text="Matematik", colorText="#fff", colorBackground="#111")]
+    ue = make_user_event("abc", owner_id=7)
+    ue.tags = tags
+    event = map_user_event(ue, current_user_id=7)
+    assert len(event.tags) == 1
+    assert event.tags[0].code == "math"
+
+
+def test_tags_round_trip():
+    tags = [Tag(code="art", text="Konst", colorText="#fff", colorBackground="#abc")]
+    event = _make_event_with_tags(tags)
+    ue = map_event_to_user_event(event, owner_id=42)
+    # Simulate read-back via extended user event
+    extended = DummyExtendedUserEvent(
+        _id="123",
+        userId=42,
+        hosts=[],
+        suggested_hosts=[],
+        name=ue.name,
+        location=None,
+        start=ue.start,
+        end=ue.end,
+        description=ue.description,
+        reports=[],
+        attendees=[],
+        maxAttendees=ue.maxAttendees,
+        tags=ue.tags,
+        ownerName="Test Owner",
+        hostNames=[],
+        attendeeNames=[],
+    )
+    result = map_user_event(extended, current_user_id=42)
+    assert len(result.tags) == 1
+    assert result.tags[0].code == "art"
+    assert result.tags[0].text == "Konst"
 

--- a/backend/v1/api/interests.py
+++ b/backend/v1/api/interests.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 from typing import List
 from v1.db.models.user import UserInterest
+from v1.events.events_model import Tag
 from v1.request_filter import validate_request
 
 interests_v1 = APIRouter(prefix="/v1")
@@ -75,3 +76,30 @@ INTEREST_CATEGORIES: List[InterestCategory] = [
 @interests_v1.get("/interests", response_model=List[InterestCategory])
 async def get_interest_categories(current_user: dict = Depends(validate_request)):
     return INTEREST_CATEGORIES
+
+
+_PALETTE = [
+    ('#7c3aed', '#ffffff'),  # purple
+    ('#0d9488', '#ffffff'),  # teal
+    ('#ea580c', '#ffffff'),  # orange
+    ('#e11d48', '#ffffff'),  # rose
+    ('#0284c7', '#ffffff'),  # sky
+    ('#65a30d', '#ffffff'),  # lime
+    ('#d97706', '#ffffff'),  # amber
+    ('#475569', '#ffffff'),  # slate
+]
+
+_INTEREST_TAGS: List[Tag] = [
+    Tag(
+        code=interest.name.lower(),
+        text=interest.value,
+        colorBackground=_PALETTE[i % len(_PALETTE)][0],
+        colorText=_PALETTE[i % len(_PALETTE)][1],
+    )
+    for i, interest in enumerate(UserInterest)
+]
+
+
+@interests_v1.get("/tags", response_model=List[Tag])
+async def get_interest_tags():
+    return _INTEREST_TAGS

--- a/backend/v1/events/events_mappers.py
+++ b/backend/v1/events/events_mappers.py
@@ -180,7 +180,7 @@ def map_user_event(ue: ExtendedUserEvent, current_user_id: int) -> Event:
         admin=[ue.userId],
         hosts=[EventHost(userId=h.userId, fullName="") for h in (ue.hosts or [])],
         name=ue.name,
-        tags=[],
+        tags=list(ue.tags) if ue.tags else [],
         locationDescription=ue.location.description if ue.location else None,
         address=ue.location.address if ue.location else None,
         locationMarker=ue.location.marker if ue.location else None,
@@ -242,5 +242,6 @@ def map_event_to_user_event(event: Event, owner_id: int, existing: UserEvent | N
         reports=(existing.reports if existing else []),
         attendees=[Attendee(userId=a.userId) for a in (existing.attendees if existing else [])],
         maxAttendees=event.maxAttendees,
+        tags=list(event.tags) if event.tags else [],
     )
     return ue

--- a/backend/v1/user_events/user_events_model.py
+++ b/backend/v1/user_events/user_events_model.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from pydantic import BaseModel, Field, field_validator
 from v1.shared.model_with_id import ModelWithId
 from typing import List, Optional
+from v1.events.events_model import Tag
 
 
 class Attendee(BaseModel):
@@ -45,6 +46,7 @@ class UserEvent(ModelWithId):
                                   }])
     attendees: List[Attendee] = Field([], example=[{"userId": 123}])
     maxAttendees: Optional[int] = Field(None, example=10)
+    tags: List[Tag] = Field([], example=[])
 
     @field_validator('start', 'end', mode='before')
     @classmethod

--- a/mensasverige/api_schema/types.ts
+++ b/mensasverige/api_schema/types.ts
@@ -25,3 +25,4 @@ export type UserUpdate = components["schemas"]["UserUpdate"];
 export type ValidationError = components["schemas"]["ValidationError"];
 export type ProfileOptionItem = components["schemas"]["ProfileOptionItem"];
 export type ProfileOptionCategory = components["schemas"]["ProfileOptionCategory"];
+export type Tag = components["schemas"]["Tag"];

--- a/mensasverige/features/events/components/CreateEventCard.tsx
+++ b/mensasverige/features/events/components/CreateEventCard.tsx
@@ -21,6 +21,8 @@ import { createEventCardStyles } from '../styles/eventCardStyles';
 import { createEditableFieldStyles } from '@/features/common/styles/editableFieldStyles';
 import { ExtendedEvent } from '../types/eventUtilTypes';
 import { createExtendedEvent } from '../utils/eventUtils';
+import { Tag } from '../../../api_schema/types';
+import TagPicker from './TagPicker';
 
 interface CreateEventCardProps {
   onEventCreated?: (event: ExtendedEvent) => void;
@@ -39,6 +41,7 @@ const CreateEventCard: React.FC<CreateEventCardProps> = ({
 }) => {
   const { user } = useStore();
   const colorScheme = useColorScheme();
+  const [selectedTags, setSelectedTags] = useState<Tag[]>(existingEvent?.tags ?? []);
   const eventCardStyles = createEventCardStyles(colorScheme ?? 'light');
   const editableFieldStyles = createEditableFieldStyles(colorScheme ?? 'light');
   const [editingField, setEditingField] = useState<string | null>(null);
@@ -125,6 +128,7 @@ const CreateEventCard: React.FC<CreateEventCardProps> = ({
           maxAttendees: eventData.maxAttendees || null,
           latitude: eventData.latitude,
           longitude: eventData.longitude,
+          tags: selectedTags,
         };
         console.log('Updating event:', eventToUpdate);
 
@@ -156,7 +160,7 @@ const CreateEventCard: React.FC<CreateEventCardProps> = ({
           parentEvent: null,
           admin: user ? [user.userId] : [],
           hosts: [],
-          tags: [],
+          tags: selectedTags,
           attendees: user ? [{ userId: user.userId }] : [],
           queue: [],
           extras: {},
@@ -289,6 +293,13 @@ const CreateEventCard: React.FC<CreateEventCardProps> = ({
           }}
           onValueChange={(value) => setEventData(prev => ({ ...prev, description: value }))}
           multiline
+        />
+
+        <View style={eventCardStyles.divider} />
+        <TagPicker
+          selectedTags={selectedTags}
+          userInterests={(user?.interests ?? []) as string[]}
+          onChange={setSelectedTags}
         />
 
         {!hideButtons && (

--- a/mensasverige/features/events/components/TagPicker.tsx
+++ b/mensasverige/features/events/components/TagPicker.tsx
@@ -1,0 +1,97 @@
+import React, { useMemo } from 'react';
+import { View, Text, Pressable, StyleSheet, useColorScheme } from 'react-native';
+import { Tag } from '../../../api_schema/types';
+import { INTEREST_TAGS, sortByUserInterests } from '../utils/interestTags';
+
+interface TagPickerProps {
+  selectedTags: Tag[];
+  userInterests: string[];
+  onChange: (tags: Tag[]) => void;
+}
+
+const TagPicker: React.FC<TagPickerProps> = ({ selectedTags, userInterests, onChange }) => {
+  const colorScheme = useColorScheme();
+  const isDark = colorScheme === 'dark';
+
+  const sorted = useMemo(
+    () => sortByUserInterests(INTEREST_TAGS, userInterests),
+    [userInterests]
+  );
+
+  const selectedCodes = useMemo(
+    () => new Set(selectedTags.map(t => t.code)),
+    [selectedTags]
+  );
+
+  const toggle = (tag: Tag) => {
+    if (selectedCodes.has(tag.code)) {
+      onChange(selectedTags.filter(t => t.code !== tag.code));
+    } else {
+      onChange([...selectedTags, tag]);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={[styles.label, isDark && styles.labelDark]}>Taggar</Text>
+      <View style={styles.chips}>
+        {sorted.map(tag => {
+          const selected = selectedCodes.has(tag.code);
+          return (
+            <Pressable
+              key={tag.code}
+              onPress={() => toggle(tag)}
+              style={[
+                styles.chip,
+                selected
+                  ? { backgroundColor: tag.colorBackground, borderColor: tag.colorBackground }
+                  : { backgroundColor: 'transparent', borderColor: tag.colorBackground },
+              ]}
+            >
+              <Text
+                style={[
+                  styles.chipText,
+                  { color: selected ? tag.colorText : tag.colorBackground },
+                ]}
+              >
+                {tag.text}
+              </Text>
+            </Pressable>
+          );
+        })}
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    marginTop: 12,
+  },
+  label: {
+    fontSize: 14,
+    fontWeight: '500',
+    color: '#374151',
+    marginBottom: 8,
+  },
+  labelDark: {
+    color: '#d1d5db',
+  },
+  chips: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+  },
+  chip: {
+    borderWidth: 1.5,
+    borderRadius: 16,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+  },
+  chipText: {
+    fontSize: 13,
+    fontWeight: '500',
+  },
+});
+
+export default TagPicker;

--- a/mensasverige/features/events/components/TagPicker.tsx
+++ b/mensasverige/features/events/components/TagPicker.tsx
@@ -1,7 +1,8 @@
 import React, { useMemo } from 'react';
 import { View, Text, Pressable, StyleSheet, useColorScheme } from 'react-native';
 import { Tag } from '../../../api_schema/types';
-import { INTEREST_TAGS, sortByUserInterests } from '../utils/interestTags';
+import { sortByUserInterests } from '../utils/interestTags';
+import useStore from '../../common/store/store';
 
 interface TagPickerProps {
   selectedTags: Tag[];
@@ -12,10 +13,11 @@ interface TagPickerProps {
 const TagPicker: React.FC<TagPickerProps> = ({ selectedTags, userInterests, onChange }) => {
   const colorScheme = useColorScheme();
   const isDark = colorScheme === 'dark';
+  const interestTags = useStore(s => s.interestTags);
 
   const sorted = useMemo(
-    () => sortByUserInterests(INTEREST_TAGS, userInterests),
-    [userInterests]
+    () => sortByUserInterests(interestTags, userInterests),
+    [interestTags, userInterests]
   );
 
   const selectedCodes = useMemo(

--- a/mensasverige/features/events/components/UnifiedEventCard.tsx
+++ b/mensasverige/features/events/components/UnifiedEventCard.tsx
@@ -144,6 +144,7 @@ const UnifiedEventCard: React.FC<{
                 categoryCode={category.code || ''}
                 showLabel={true}
                 size="medium"
+                tagFallback={{ text: category.text, colorText: category.colorText, colorBackground: category.colorBackground }}
               />
             ))}
           </View>

--- a/mensasverige/features/events/components/badges/CategoryBadge.tsx
+++ b/mensasverige/features/events/components/badges/CategoryBadge.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react';
 import {
   View,
+  Text,
   StyleSheet,
   TouchableOpacity,
 } from 'react-native';
@@ -16,6 +17,7 @@ export interface CategoryBadgeProps {
   showLabel?: boolean;
   size?: 'x-small' | 'small' | 'medium';
   onPress?: () => void;
+  tagFallback?: { text: string; colorText: string; colorBackground: string };
 }
 
 // Category definitions with colors and icons
@@ -72,7 +74,8 @@ const CategoryBadge: React.FC<CategoryBadgeProps> = ({
   label,
   showLabel = true,
   size: labelSize = 'medium',
-  onPress
+  onPress,
+  tagFallback,
 }) => {
   // Determine if this is a category or event type badge
   let config: BadgeConfig | null = null;
@@ -86,7 +89,27 @@ const CategoryBadge: React.FC<CategoryBadgeProps> = ({
   }
 
   if (!config) {
-    return null;
+    if (!tagFallback) return null;
+    const chip = (
+      <View
+        style={{
+          borderWidth: 1.5,
+          borderRadius: 16,
+          paddingHorizontal: 10,
+          paddingVertical: 4,
+          backgroundColor: tagFallback.colorBackground + '20',
+          borderColor: tagFallback.colorBackground,
+        }}
+      >
+        <Text style={{ fontSize: 12, fontWeight: '500', color: tagFallback.colorBackground }}>
+          {tagFallback.text}
+        </Text>
+      </View>
+    );
+    if (onPress) {
+      return <TouchableOpacity onPress={onPress} activeOpacity={0.7}>{chip}</TouchableOpacity>;
+    }
+    return chip;
   }
 
   let iconSize: number;

--- a/mensasverige/features/events/components/badges/CategoryBadge.tsx
+++ b/mensasverige/features/events/components/badges/CategoryBadge.tsx
@@ -88,6 +88,35 @@ const CategoryBadge: React.FC<CategoryBadgeProps> = ({
     config = CATEGORY_CONFIG[categoryCode as keyof typeof CATEGORY_CONFIG];
   }
 
+  let iconSize: number;
+  let badgeSize: number;
+
+  switch (labelSize) {
+    case 'x-small':
+      badgeSize = 16;
+      iconSize = 10;
+      break;
+    case 'small':
+      badgeSize = 26;
+      iconSize = 13;
+      break;
+    case 'medium':
+    default:
+      badgeSize = 32;
+      iconSize = 16;
+      break;
+  }
+
+  // useMemo must be called unconditionally (Rules of Hooks) — guard inside the callback
+  const badgeCircleStyle = useMemo(() => ({
+    borderRadius: badgeSize / 2,
+    width: badgeSize,
+    height: badgeSize,
+    alignItems: 'center' as const,
+    justifyContent: 'center' as const,
+    backgroundColor: (config?.color ?? '#000000') + '20',
+  }), [badgeSize, config?.color]);
+
   if (!config) {
     if (!tagFallback) return null;
     const chip = (
@@ -111,34 +140,6 @@ const CategoryBadge: React.FC<CategoryBadgeProps> = ({
     }
     return chip;
   }
-
-  let iconSize: number;
-  let badgeSize: number;
-
-  switch (labelSize) {
-    case 'x-small':
-      badgeSize = 16;
-      iconSize = 10;
-      break;
-    case 'small':
-      badgeSize = 26;
-      iconSize = 13;
-      break;
-    case 'medium':
-    default:
-      badgeSize = 32;
-      iconSize = 16;
-      break;
-  }
-
-  const badgeCircleStyle = useMemo(() => ({
-    borderRadius: badgeSize / 2,
-    width: badgeSize,
-    height: badgeSize,
-    alignItems: 'center' as const,
-    justifyContent: 'center' as const,
-    backgroundColor: config.color + '20',
-  }), [badgeSize, config.color]);
 
   const icon = isEventType && config.icon === 'official'
     ? <OfficialEventIcon size={iconSize} color={config.color} />

--- a/mensasverige/features/events/hooks/useEvents.ts
+++ b/mensasverige/features/events/hooks/useEvents.ts
@@ -1,7 +1,7 @@
 import { useEffect, useCallback } from 'react';
 import { GroupedEvents, ExtendedEvent } from '../types/eventUtilTypes';
 import { createExtendedEvent } from '../utils/eventUtils';
-import { fetchEvents, attendEvent, unattendEvent } from '../services/eventService';
+import { fetchEvents, attendEvent, unattendEvent, fetchInterestTags } from '../services/eventService';
 import { getUsersByIds } from '../../account/services/userService';
 import useStore from '../../common/store/store';
 import { EventFilterOptions } from '../store/EventsSlice';
@@ -77,6 +77,7 @@ export const useEvents = (options: UseEventsOptions = {}): UseEventsReturn => {
     setEventsRefreshing,
     setEventsLastFetched,
     setEventsInitialized,
+    setInterestTags,
 
     // Dashboard events (attending + upcoming with limit)
     dashboardGroupedEvents,
@@ -206,6 +207,15 @@ export const useEvents = (options: UseEventsOptions = {}): UseEventsReturn => {
       refetch().catch(error => console.error('Error in initial loadEvents:', error));
     }
   }, [eventsInitialized, refetch]);
+
+  // Fetch the interest tag catalog from the backend once on first mount.
+  // Falls back to the static list (already in the store) on error.
+  useEffect(() => {
+    fetchInterestTags().then(tags => {
+      if (tags.length > 0) setInterestTags(tags);
+    });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Auto-refresh singleton: multiple consumers share one interval
   useEffect(() => {

--- a/mensasverige/features/events/services/eventService.ts
+++ b/mensasverige/features/events/services/eventService.ts
@@ -1,5 +1,5 @@
 import apiClient from '../../common/services/apiClient';
-import {ExternalRoot, Event} from '../../../api_schema/types';
+import {ExternalRoot, Event, Tag} from '../../../api_schema/types';
 
 export const fetchExternalRoot = async (): Promise<ExternalRoot> => {
   return apiClient
@@ -124,5 +124,15 @@ export const unattendEvent = async (eventId: string): Promise<boolean> => {
     .catch(error => {
       console.error('Error unattending event:', error);
       throw error;
+    });
+};
+
+export const fetchInterestTags = async (): Promise<Tag[]> => {
+  return apiClient
+    .get('/tags')
+    .then(response => response.data as Tag[])
+    .catch(error => {
+      console.warn('Failed to fetch interest tags from backend, using static fallback:', error.message);
+      return [];
     });
 };

--- a/mensasverige/features/events/store/EventsSlice.ts
+++ b/mensasverige/features/events/store/EventsSlice.ts
@@ -1,7 +1,8 @@
 import {StateCreator} from 'zustand';
 import { GroupedEvents, ExtendedEvent } from '../types/eventUtilTypes';
 import { groupEventsByDate } from '../utils/eventUtils';
-import { ExternalRoot } from '../../../api_schema/types';
+import { ExternalRoot, Tag } from '../../../api_schema/types';
+import { INTEREST_TAGS } from '../utils/interestTags';
 
 // Import EventFilterOptions type
 export interface EventFilterOptions {
@@ -19,6 +20,8 @@ export interface EventsSlice {
   eventsRefreshing: boolean;
   eventsLastFetched: Date | null;
   eventsInitialized: boolean;
+  interestTags: Tag[];
+  setInterestTags: (tags: Tag[]) => void;
 
   // Parent event info
   eventInfo: ExternalRoot | null;
@@ -152,6 +155,7 @@ export const createEventsSlice: StateCreator<EventsSlice> = (set, get) => ({
   eventsRefreshing: false,
   eventsLastFetched: null,
   eventsInitialized: false,
+  interestTags: INTEREST_TAGS,
 
   // Parent event info
   eventInfo: null,
@@ -229,6 +233,7 @@ export const createEventsSlice: StateCreator<EventsSlice> = (set, get) => ({
   setEventsRefreshing: (eventsRefreshing: boolean) => set({eventsRefreshing}),
   setEventsLastFetched: (eventsLastFetched: Date | null) => set({eventsLastFetched}),
   setEventsInitialized: (eventsInitialized: boolean) => set({eventsInitialized}),
+  setInterestTags: (interestTags: Tag[]) => set({interestTags}),
 
   // Event info actions
   setEventInfo: (eventInfo: ExternalRoot | null) => set({eventInfo}),

--- a/mensasverige/features/events/utils/interestTags.ts
+++ b/mensasverige/features/events/utils/interestTags.ts
@@ -1,0 +1,128 @@
+import { Tag } from '../../../api_schema/types';
+
+const PALETTE = [
+  { bg: '#7c3aed', fg: '#ffffff' }, // purple
+  { bg: '#0d9488', fg: '#ffffff' }, // teal
+  { bg: '#ea580c', fg: '#ffffff' }, // orange
+  { bg: '#e11d48', fg: '#ffffff' }, // rose
+  { bg: '#0284c7', fg: '#ffffff' }, // sky
+  { bg: '#65a30d', fg: '#ffffff' }, // lime
+  { bg: '#d97706', fg: '#ffffff' }, // amber
+  { bg: '#475569', fg: '#ffffff' }, // slate
+];
+
+function t(code: string, text: string, idx: number): Tag {
+  const c = PALETTE[idx % PALETTE.length];
+  return { code, text, colorText: c.fg, colorBackground: c.bg };
+}
+
+export const INTEREST_TAGS: Tag[] = [
+  t('konst',               'Konst',                          0),
+  t('teater',              'Teater',                         1),
+  t('slojd_handarbete',    'Slöjd och handarbete',           2),
+  t('pyssel',              'Pyssel',                         3),
+  t('fotografi',           'Fotografi',                      4),
+  t('skrivande',           'Skrivande',                      5),
+  t('inredningsdesign',    'Inredningsdesign',                6),
+  t('loppis',              'Loppis och second hand',         7),
+  t('spela_instrument',    'Spela instrument',               0),
+  t('sjunga',              'Sjunga',                         1),
+  t('producera_musik',     'Producera musik',                2),
+  t('konsert',             'Gå på konsert',                  3),
+  t('lyssna_musik',        'Lyssna på musik',                4),
+  t('bollsport',           'Bollsport',                      5),
+  t('idrott',              'Idrott',                         6),
+  t('motorsport',          'Motorsport',                     7),
+  t('skidor',              'Skidor och vintersport',         0),
+  t('lopning',             'Löpning',                        1),
+  t('konditionstraning',   'Konditionsträning',              2),
+  t('kampsport',           'Kampsport',                      3),
+  t('hastsport',           'Hästsport',                      4),
+  t('klattring',           'Klättring/Bouldering',           5),
+  t('dykning',             'Dykning',                        6),
+  t('gym',                 'Gym',                            7),
+  t('yoga',                'Yoga',                           0),
+  t('golf',                'Golf',                           1),
+  t('dans',                'Dans',                           2),
+  t('bocker',              'Böcker och litteratur',          3),
+  t('film_tv',             'Film och tv-serier',             4),
+  t('fest',                'Fest',                           5),
+  t('tvspel',              'Tv-spel/datorspel',              6),
+  t('bradspel',            'Brädspel',                       7),
+  t('kortspel',            'Kortspel',                       0),
+  t('odling',              'Odling och trädgårdsarbete',     1),
+  t('botanik',             'Botanik',                        2),
+  t('lantbruk',            'Lantbruk',                       3),
+  t('friluftsliv',         'Friluftsliv',                    4),
+  t('vandring',            'Vandring och hiking',            5),
+  t('husdjur',             'Husdjur',                        6),
+  t('zoologi',             'Zoologi',                        7),
+  t('camping',             'Camping',                        0),
+  t('fiske',               'Fiske',                          1),
+  t('fagelskadning',       'Fågelskådning',                  2),
+  t('programmering',       'Programmering och IT',           3),
+  t('elektronik',          'Elektronik',                     4),
+  t('teknikprylar',        'Teknikprylar',                   5),
+  t('vetenskap',           'Vetenskap och forskning',        6),
+  t('matematik',           'Matematik',                      7),
+  t('astronomi',           'Astronomi',                      0),
+  t('akademiska_studier',  'Akademiska studier',             1),
+  t('livslangt_larande',   'Livslångt lärande',              2),
+  t('historia',            'Historia',                       3),
+  t('lasning',             'Läsning',                        4),
+  t('fonder_aktier',       'Fonder och Aktier',              5),
+  t('foretagande',         'Företagande och entreprenörskap', 6),
+  t('politik',             'Politik',                        7),
+  t('kultur',              'Kultur',                         0),
+  t('sprak',               'Språk',                          1),
+  t('resor',               'Resor',                          2),
+  t('filosofi',            'Filosofi',                       3),
+  t('psykologi',           'Psykologi',                      4),
+  t('personlig_utveckling','Personlig utveckling',           5),
+  t('religion',            'Religion',                       6),
+  t('meditation',          'Meditation',                     7),
+  t('sex_sexualitet',      'Sex och sexualitet',             0),
+  t('relationer',          'Relationer och relationstyper',  1),
+  t('foraldraskap',        'Föräldraskap och uppfostran',    2),
+  t('restaurang',          'Restaurang och matupplevelser',  3),
+  t('matlagning',          'Matlagning',                     4),
+  t('bakning',             'Bakning',                        5),
+  t('ol',                  'Öl',                             6),
+  t('whisky',              'Whisky',                         7),
+  t('vin',                 'Vin',                            0),
+  t('klader',              'Kläder och personlig stil',      1),
+  t('har_makeup',          'Hår och makeup',                 2),
+  t('aterbruk',            'Återbruk',                       3),
+  t('prepping',            'Prepping',                       4),
+  t('sjalvhushall',        'Självhushåll',                   5),
+  t('bygg_renovering',     'Bygg och renovering',            6),
+];
+
+// Map from interest label (UserInterest enum value) to Tag
+const BY_LABEL: Record<string, Tag> = Object.fromEntries(
+  INTEREST_TAGS.map(tag => [tag.text, tag])
+);
+
+// Map from tag code to Tag
+const BY_CODE: Record<string, Tag> = Object.fromEntries(
+  INTEREST_TAGS.map(tag => [tag.code, tag])
+);
+
+export function interestToTag(interestLabel: string): Tag | undefined {
+  return BY_LABEL[interestLabel];
+}
+
+export function tagByCode(code: string): Tag | undefined {
+  return BY_CODE[code];
+}
+
+/** Sort tags so the user's own interests appear first. */
+export function sortByUserInterests(tags: Tag[], userInterestLabels: string[]): Tag[] {
+  const userCodes = new Set(
+    userInterestLabels.map(l => BY_LABEL[l]?.code).filter(Boolean)
+  );
+  return [
+    ...tags.filter(t => userCodes.has(t.code)),
+    ...tags.filter(t => !userCodes.has(t.code)),
+  ];
+}


### PR DESCRIPTION
## Summary
- Adds \`TagPicker\` chip component to event create/edit form — users pick tags from the 79 Swedish UserInterest categories
- User's own interests sort to the top of the picker
- Selected tags are saved on the event and render as colored chips in the event card
- Existing category filter (filter events by tag code) works automatically for user-created event tags

## Test plan
- [ ] Create a new event, pick 2-3 tags, save — confirm tags appear on the event card
- [ ] Edit the event — confirm pre-selected tags are shown
- [ ] Remove a tag, save — confirm it's gone from the card
- [ ] Confirm existing official events (with F/M/S/etc codes) still render correctly
- [ ] Confirm event filter by category works for interest-tagged events