### PR TITLE
Harden auth: stop logging tokens and credentials

### DIFF
--- a/backend/v1/api/auth.py
+++ b/backend/v1/api/auth.py
@@ -46,72 +46,45 @@ class AuthResponse(BaseModel):
     user: User
 
 
-@auth_v1.post("/authm")
-def authm(request: AuthRequest, http_response: Response) -> AuthResponse:
-    response = check_review_user_creds(request.username, request.password)
-
-    if response is not None:
-        # Important, so we can look at the logs to see when the app is being reviewed ;)
-        logging.info(f"Review user logged in! {request.username}")
-    else:
-        response = loginm(request.username, request.password)
-
-    logging.info(f"response_json: {response}")
+def _do_login(login_response: dict, http_response: Response) -> AuthResponse:
     try:
-        memberId = int(response["memberId"])
+        memberId = int(login_response["memberId"])
         user = get_user(memberId)
         if not user:
-            user = create_user(response)
+            user = create_user(login_response)
         else:
-            update_user_from_authresponse(memberId, response)
+            update_user_from_authresponse(memberId, login_response)
             user = get_user(memberId)
-    except KeyError as e:
-        print("memberId not found in response")
+    except KeyError:
         raise HTTPException(status_code=400, detail="Invalid credentials")
 
-    save_external_token(user["userId"], response["token"],
-                        convert_string_to_datetime(response["validThrough"]))
+    save_external_token(user["userId"], login_response["token"],
+                        convert_string_to_datetime(login_response["validThrough"]))
     accesstoken = create_access_token(user["userId"])
     refresh = create_refresh_token(user["userId"])
     _set_refresh_cookie(http_response, refresh)
 
-    authresponse = AuthResponse(
+    return AuthResponse(
         accessToken=accesstoken,
         refreshToken=refresh,
         accessTokenExpiry=get_token_expiry(accesstoken),
         user=user)
-    return authresponse
+
+
+@auth_v1.post("/authm")
+def authm(request: AuthRequest, http_response: Response) -> AuthResponse:
+    response = check_review_user_creds(request.username, request.password)
+    if response is not None:
+        logging.info("Review user logged in: %s", request.username)
+    else:
+        response = loginm(request.username, request.password)
+    return _do_login(response, http_response)
 
 
 @auth_v1.post("/authb")
 def authb(request: AuthRequest, http_response: Response) -> AuthResponse:
     response = loginb(request.username, request.password)
-
-    logging.info(f"Non member login, response_json: {response}")
-    try:
-        memberId = int(response["memberId"])
-        user = get_user(memberId)
-        if not user:
-            user = create_user(response)
-        else:
-            update_user_from_authresponse(memberId, response)
-            user = get_user(memberId)
-    except KeyError as e:
-        print("memberId not found in response")
-        raise HTTPException(status_code=400, detail="Invalid credentials")
-
-    save_external_token(user["userId"], response["token"],
-                        convert_string_to_datetime(response["validThrough"]))
-    accesstoken = create_access_token(user["userId"])
-    refresh = create_refresh_token(user["userId"])
-    _set_refresh_cookie(http_response, refresh)
-
-    authresponse = AuthResponse(
-        accessToken=accesstoken,
-        refreshToken=refresh,
-        accessTokenExpiry=get_token_expiry(accesstoken),
-        user=user)
-    return authresponse
+    return _do_login(response, http_response)
 
 
 class RefreshTokenRequest(BaseModel):

--- a/backend/v1/db/review_users.py
+++ b/backend/v1/db/review_users.py
@@ -26,9 +26,7 @@ review_users: List[User] = [
 
 
 def check_review_user_creds(username: str, password: str) -> dict:
-    logging.info(
-        f"Checking if user creds: {username}, matches review user creds: {APPLE_REVIEW_USER}, {REVIEW_PASSWORD} or {GOOGLE_REVIEW_USER}, {REVIEW_PASSWORD}"
-    )
+    logging.info("Checking review user credentials")
     date = get_current_time().replace(tzinfo=None)
     delta = timedelta(hours=12)
     date += delta

--- a/backend/v1/request_filter.py
+++ b/backend/v1/request_filter.py
@@ -15,13 +15,16 @@ async def validate_request(
         try:
             valid, payload = verify_access_token(bearer.credentials)
             if not valid:
-                logger.error("Invalid token: ", bearer.credentials)
+                logger.warning("Token validation failed: %s", payload)
                 raise HTTPException(status_code=401, detail="Unauthorized")
             user = get_user(int(payload.get("sub")))
+            if not user:
+                raise HTTPException(status_code=401, detail="Unauthorized")
             return user
-        except Exception as e:
-            logging.error("Error validating token: ", bearer.credentials)
-            logging.error(e)
+        except HTTPException:
+            raise
+        except (ValueError, TypeError) as e:
+            logger.warning("Token subject parse error: %s", type(e).__name__)
             raise HTTPException(status_code=401, detail="Unauthorized")
     else:
         logging.error("No token provided")


### PR DESCRIPTION
Split out of #304 (event-tags) as its own concern.

## What
- **request_filter**: stop logging bearer tokens; log only the validation-failure reason. Narrow the `except` to `ValueError`/`TypeError` so DB errors surface as 500 instead of being masked as 401. Add a null-check for the resolved user.
- **review_users**: replace the credential-logging line with a generic message so `APPLE_REVIEW_USER`/`REVIEW_PASSWORD` never appear in logs.
- **auth**: extract a shared `_do_login` helper (authm/authb become ~2 lines each); stop logging the full auth response (it contained an external token).

## Why
Security/log-hygiene fixes with no relation to the event-tags feature. Independent of every other split branch — mergeable on its own.

Severity is low (logs are private; the review creds are shared with Apple/Google review anyway), so no credential rotation is required.