### PR TITLE
Add 401 token-refresh retry in apiClient

### DIFF
--- a/mensasverige/features/common/services/apiClient.ts
+++ b/mensasverige/features/common/services/apiClient.ts
@@ -19,7 +19,7 @@
  */
 import axios, {AxiosResponse} from 'axios';
 import useStore from '../store/store';
-import {getOrRefreshAccessToken} from './authService';
+import {getOrRefreshAccessToken, forceRefreshToken} from './authService';
 import { UpdateCheckResponseInterceptor, UpdateCheckErrorInterceptor } from '@/features/updateCheck/services/UpdateCheckResponseInterceptor';
 import * as Application from 'expo-application';
 import { Platform } from 'react-native';
@@ -61,7 +61,7 @@ apiClient.interceptors.response.use(
     store.setBackendConnection(true);
     return response;
   },
-  (error: any) => {
+  async (error: any) => {
     const isNetworkError = error.message.includes('Network Error');
     if (isNetworkError) {
       const store = useStore.getState();
@@ -71,11 +71,20 @@ apiClient.interceptors.response.use(
     const originalRequest = error.config;
     if (
       error.response?.status === 401 &&
+      originalRequest &&
       !originalRequest._retry &&
-      !originalRequest.url.includes('/authm') &&
-      !originalRequest.url.includes('/authb')
+      !originalRequest.url?.includes('/authm') &&
+      !originalRequest.url?.includes('/authb') &&
+      !originalRequest.url?.includes('/refresh_token')
     ) {
       originalRequest._retry = true;
+      try {
+        const newToken = await forceRefreshToken();
+        originalRequest.headers.Authorization = `Bearer ${newToken}`;
+        return apiClient(originalRequest);
+      } catch {
+        useStore.getState().setUser(null);
+      }
     }
     return Promise.reject(error);
   },

--- a/mensasverige/features/common/services/authService.ts
+++ b/mensasverige/features/common/services/authService.ts
@@ -49,37 +49,28 @@ export const authenticate = async (username: string, password: string, testMode:
             } as AuthRequest
         )
         .then(async response => {
-            if (response.status === 200) {
-                const authresponse: AuthResponse = response.data;
-                console.log('Auth response', authresponse);
-                return storeAndValidateAuthResponse(authresponse);
-            } else {
-                if (response.status === 401) {
-                    console.error('Invalid credentials');
-                    throw new Error('Fel användarnamn eller lösenord.');
-                } else if (response.status === 422) {
-                    const data: HTTPValidationError = response.data;
-                    const detail = data.detail as ValidationError[];
-                    if (detail.some(item => item.msg === 'Test mode is not enabled')) {
-                        throw new Error('Testläge är inte aktiverat i backend. Appen borde inte köras i testläge.');
-                    } else {
-                        console.error('backend responded with status 400', data);
-                        throw new Error('Något gick fel. Försök igen senare.');
-                    }
-                }
-                else {
-                    console.error('backend responded with status', response.status);
-                    throw new Error('Något gick fel. Försök igen senare.');
-                }
-            }
+            return storeAndValidateAuthResponse(response.data as AuthResponse);
         })
         .catch(error => {
-            console.error('Login error', error.message || error);
-            if (error.message.includes('Network Error')) {
-                throw new Error(`Det går inte att nå servern just nu. Försök igen om en stund.`);
-            } else {
+            const status = error.response?.status;
+            if (status === 401 || status === 400) {
+                throw new Error('Fel användarnamn eller lösenord.');
+            }
+            if (status === 422) {
+                const data: HTTPValidationError = error.response.data;
+                const detail = data.detail as ValidationError[];
+                if (detail?.some(item => item.msg === 'Test mode is not enabled')) {
+                    throw new Error('Testläge är inte aktiverat i backend. Appen borde inte köras i testläge.');
+                }
                 throw new Error('Något gick fel. Försök igen senare.');
             }
+            if (error.message?.includes('Network Error')) {
+                throw new Error('Det går inte att nå servern just nu. Försök igen om en stund.');
+            }
+            if (error.message) {
+                throw error;
+            }
+            throw new Error('Något gick fel. Försök igen senare.');
         });
 }
 
@@ -124,6 +115,14 @@ export const refreshAccessToken = async (refreshToken: string): Promise<string> 
         return data.accessToken;
     }
     throw new Error('Failed to refresh access token');
+}
+
+// Force a token refresh regardless of the cached expiry. Used by the 401
+// response interceptor in apiClient when the server rejects a token we
+// thought was still valid (e.g. clock skew, rotation).
+export const forceRefreshToken = async (): Promise<string> => {
+    const storedRefreshToken = Platform.OS === 'web' ? '' : (await SecureStore.getItem('refreshToken')) ?? '';
+    return refreshAccessToken(storedRefreshToken);
 }
 
 export const attemptLoginWithStoredCredentials = async (): Promise<AuthResponse> => {


### PR DESCRIPTION
Split out of #304 (event-tags) as its own concern.

## What
- **apiClient**: on a 401, force a token refresh and retry the original request once.
- **authService**: new `forceRefreshToken` export that always hits `/refresh_token` regardless of cached expiry; used by the 401 interceptor. Move the status checks into `.catch()` where `error.response.status` is actually populated.

## Why
Auth/networking resilience — unrelated to the event-tags feature. Independent of the other split branches.